### PR TITLE
`bws`

### DIFF
--- a/potato/create_task_cli.py
+++ b/potato/create_task_cli.py
@@ -20,20 +20,18 @@ def yes_or_no(question):
 
 
 def get_annotation_type():
+    q = (
+        "What type of annotation is this? Possible types are...\n"
+        + "  multiselect -- checkboxes where users can pick 0 or more\n"
+        + "  radio -- radio buttons where users must pick 1\n"
+        + "  text -- free text entry box\n"
+        + "  likert -- a likert scale with an order list of radio buttons\n"
+        + "  bws -- a set of options where users select the most/least extreme "
+        + "options w.r.t. some scale\n\n"
+    )
+
+    options = ("multiselect", "radio", "text", "likert", "bws")
     while "the answer is invalid":
-
-        q = (
-            "What type of annotation is this? Possible types are...\n"
-            + "  multiselect -- checkboxes where users can pick 0 or more\n"
-            + "  radio -- radio buttons where users must pick 1\n"
-            + "  text -- free text entry box\n"
-            + "  likert -- a likert scale with an order list of radio buttons\n"
-            + "  bws -- a set of options where users select the most/least extreme "
-            + "options w.r.t. some scale\n\n"
-        )
-
-        options = ("multiselect", "radio", "text", "likert", "bws")
-
         reply = _prompt(q).lower().strip()
         if reply in options:
             return reply

--- a/potato/create_task_cli.py
+++ b/potato/create_task_cli.py
@@ -32,7 +32,7 @@ def get_annotation_type():
             + "options w.r.t. some scale\n\n"
         )
 
-        options = ["multiselect", "radio", "text", "likert", "bws"]
+        options = ("multiselect", "radio", "text", "likert", "bws")
 
         reply = _prompt(q).lower().strip()
         if reply in options:

--- a/potato/create_task_cli.py
+++ b/potato/create_task_cli.py
@@ -32,7 +32,7 @@ def get_annotation_type():
             + "options w.r.t. some scale\n\n"
         )
 
-        options = ["multiselect", "radio", "text", "likert", "btw"]
+        options = ["multiselect", "radio", "text", "likert", "bws"]
 
         reply = _prompt(q).lower().strip()
         if reply in options:


### PR DESCRIPTION
Fix a spelling mistake with possible options for annotations type when creating the config file from CLI. `bws` should now work as a valid option.

fixes #53 