### PR TITLE
Fix typo, text box, and HTML template path in `create_task_cli`

### DIFF
--- a/potato/create_task_cli.py
+++ b/potato/create_task_cli.py
@@ -39,6 +39,24 @@ def get_initial_config():
 
     config["alert_time_each_instance"] = 10000000
 
+    # The html that changes the visualiztation for your task. Change this file
+    # to influence the layout and description of your task. This is not a full
+    # HTML page, just the piece that does lays out your task's pieces
+    config["html_layout"] = "default"
+
+    # The core UI files for Potato. You should not need to change these normally.
+    #
+    # Exceptions to this might include:
+    # 1) You want to add custom CSS/fonts to style your task
+    # 2) Your layout requires additional JS/assets to render
+    # 3) You want to support additional keybinding magic
+    #
+    config["base_html_template"] = "default"
+    config["header_file"] = "default"
+
+    # This is where the actual HTML files will be generated
+    config["site_dir"] = "default"
+
     return config
 
 

--- a/potato/create_task_cli.py
+++ b/potato/create_task_cli.py
@@ -39,24 +39,6 @@ def get_initial_config():
 
     config["alert_time_each_instance"] = 10000000
 
-    # The html that changes the visualiztation for your task. Change this file
-    # to influence the layout and description of your task. This is not a full
-    # HTML page, just the piece that does lays out your task's pieces
-    config["html_layout"] = "templates/examples/plain_layout.html"
-
-    # The core UI files for Potato. You should not need to change these normally.
-    #
-    # Exceptions to this might include:
-    # 1) You want to add custom CSS/fonts to style your task
-    # 2) Your layout requires additional JS/assets to render
-    # 3) You want to support additional keybinding magic
-    #
-    config["base_html_template"] = "templates/base_template.html"
-    config["header_file"] = "templates/header.html"
-
-    # This is where the actual HTML files will be generated
-    config["site_dir"] = "potato/templates/"
-
     return config
 
 

--- a/potato/create_task_cli.py
+++ b/potato/create_task_cli.py
@@ -151,7 +151,9 @@ def create_task_cli():
             scheme["size"] = size
 
         elif atype == "text":
-            pass
+            scheme["annotation_type"] = "text"
+            scheme["name"] = name
+            scheme["description"] = desc
 
         elif atype == "mutliselect" or atype == "radio":
             # Get the options
@@ -172,7 +174,7 @@ def create_task_cli():
         if not yes_or_no("Are there more annotation types/tasks to add?"):
             break
 
-    config["annoation_schemes"] = annotation_schemes
+    config["annotation_schemes"] = annotation_schemes
 
     while True:
         config_file = input(


### PR DESCRIPTION
- fix typo: `annoation_schemes` -> `annoation_schemes`
- Add scheme for text box
- Remove default html relative paths, which will raise errors for users that installed potato through `pip`