### PR TITLE
[codex] Fix phase flow back navigation and form restoration

### DIFF
--- a/potato/flask_server.py
+++ b/potato/flask_server.py
@@ -1642,8 +1642,51 @@ def get_current_page_html(config, username):
         'total_count': user_state.get_assigned_instance_count() if hasattr(user_state, 'get_assigned_instance_count') else 0,
         'ui_config': config.get('ui_config', {}),
         'is_annotation_page': is_annotation_page,
+        'annotation_instructions': config.get('annotation_instructions', ''),
     }
-    return render_template(html_fname, **context)
+    rendered_html = render_template(html_fname, **context)
+    soup = BeautifulSoup(rendered_html, "html.parser")
+
+    phase_annotations = user_state.phase_to_page_to_label_to_value.get(phase, {}).get(page, {})
+    for label_obj, value in phase_annotations.items():
+        schema = label_obj.get_schema()
+        label = label_obj.get_name()
+        name = schema + ":::" + label
+
+        input_fields = soup.find_all(["input", "select", "textarea"], {"name": name})
+        if not input_fields:
+            input_fields = soup.find_all(["input"], {"schema": schema, "label_name": label})
+
+        for input_field in input_fields:
+            if input_field is None:
+                continue
+
+            if input_field.get('type') == 'checkbox' or input_field.get('type') == 'radio':
+                if value:
+                    if input_field.get('type') == 'radio':
+                        if input_field.get('value') == value:
+                            input_field['checked'] = True
+                    else:
+                        input_field['checked'] = True
+
+            if input_field.get('type') == 'text':
+                if isinstance(value, str):
+                    input_field['value'] = value
+
+            if input_field.get('type') == 'number':
+                input_field['value'] = str(value)
+
+            if input_field.name == 'textarea':
+                if isinstance(value, str):
+                    input_field.string = value
+
+            if input_field.name == 'select':
+                if isinstance(value, str):
+                    options = input_field.find_all("option", {"value": value})
+                    if options:
+                        options[0]["selected"] = "selected"
+
+    return str(soup)
 
 def _is_user_adjudicator(username: str) -> bool:
     """Check if a user is an authorized adjudicator."""

--- a/potato/routes.py
+++ b/potato/routes.py
@@ -1783,13 +1783,13 @@ def annotate():
                 action = request.form.get('action')
 
             if action == 'next_instance':
-                # Treat as "submit current phase page" — advance to next phase
+                # Treat as "submit current phase page" - advance to next phase
                 logger.info(f"Leaked next_instance from phase {cur_phase}, advancing phase")
                 get_user_state_manager().advance_phase(username)
                 return redirect(url_for("home"))
             elif action == 'prev_instance':
-                # No backward navigation — just redirect without changing state
-                logger.info(f"Leaked prev_instance from phase {cur_phase}, ignoring")
+                logger.info(f"Leaked prev_instance from phase {cur_phase}, moving to previous phase/page")
+                get_user_state_manager().retreat_phase(username)
                 return redirect(url_for("home"))
 
         # For non-nav POSTs (phase form submissions) and GETs, delegate to home()
@@ -1842,7 +1842,11 @@ def annotate():
 
     if action == "prev_instance":
         logger.debug(f"Moving to previous instance for user: {username}")
-        move_to_prev_instance(username)
+        moved_back = move_to_prev_instance(username)
+        if not moved_back and user_state.get_current_instance_index() <= 0:
+            logger.debug(f"User {username} is at first annotation instance, moving back to previous phase/page")
+            get_user_state_manager().retreat_phase(username)
+            return redirect(url_for("home"))
         acm = get_ai_cache_manager()
         if acm:
             acm.start_prefetch(user_state.current_instance_index,

--- a/potato/user_state_management.py
+++ b/potato/user_state_management.py
@@ -680,6 +680,12 @@ class UserStateManager:
                     ),
                 )
 
+    def retreat_phase(self, user_id: str) -> None:
+        '''Moves the user to the previous page in the current phase or the previous configured phase.'''
+        user_state = self.get_user_state(user_id)
+        phase, page = self.get_prev_user_phase_page(user_id)
+        user_state.advance_to_phase(phase, page)
+
     def _get_configured_phase_sequence(self) -> list:
         '''Return the ordered list of UserPhase enums derived from the config.
 
@@ -757,6 +763,45 @@ class UserStateManager:
                 return first_phase, first_page
 
         return UserPhase.DONE, None
+
+    def get_prev_user_phase_page(self, user_id: str) -> tuple[UserPhase, str]:
+        '''Returns the previous page for the user, either in the current phase
+           or the previous configured phase.'''
+
+        user_state = self.get_user_state(user_id)
+        cur_phase, cur_page = user_state.get_current_phase_and_page()
+
+        if cur_phase == UserPhase.LOGIN:
+            return UserPhase.LOGIN, None
+
+        if cur_phase == UserPhase.DONE:
+            config_phases = self._get_configured_phase_sequence()
+            if config_phases:
+                prev_phase = config_phases[-1]
+                if prev_phase == UserPhase.ANNOTATION:
+                    return prev_phase, None
+                prev_page = list(self.phase_type_to_name_to_page[prev_phase].keys())[-1]
+                return prev_phase, prev_page
+            return UserPhase.LOGIN, None
+
+        if cur_phase != UserPhase.ANNOTATION and cur_phase in self.phase_type_to_name_to_page:
+            pages_for_cur_phase = list(self.phase_type_to_name_to_page[cur_phase].keys())
+            if len(pages_for_cur_phase) > 1 and cur_page in pages_for_cur_phase:
+                cur_page_index = pages_for_cur_phase.index(cur_page)
+                if cur_page_index > 0:
+                    return cur_phase, pages_for_cur_phase[cur_page_index - 1]
+
+        config_phases = self._get_configured_phase_sequence()
+        if cur_phase in config_phases:
+            cur_phase_index = config_phases.index(cur_phase)
+            if cur_phase_index > 0:
+                prev_phase = config_phases[cur_phase_index - 1]
+                if prev_phase == UserPhase.ANNOTATION:
+                    return prev_phase, None
+                prev_page = list(self.phase_type_to_name_to_page[prev_phase].keys())[-1]
+                return prev_phase, prev_page
+
+        return cur_phase, cur_page
 
     def get_user_ids(self) -> list[str]:
         '''Gets all user IDs from the user state manager'''

--- a/tests/unit/phase_page_templates/survey_page.html
+++ b/tests/unit/phase_page_templates/survey_page.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <form>
+        <input type="radio" name="radio_schema:::choice" value="yes">
+        <input type="radio" name="radio_schema:::choice" value="no">
+        <input type="checkbox" name="checkbox_schema:::selected" value="true">
+        <input type="text" name="text_schema:::comment">
+        <input type="number" name="number_schema:::count">
+        <textarea name="textarea_schema:::notes"></textarea>
+        <select name="select_schema:::pick">
+            <option value="a">A</option>
+            <option value="b">B</option>
+        </select>
+    </form>
+</body>
+</html>

--- a/tests/unit/test_phase_flow_navigation.py
+++ b/tests/unit/test_phase_flow_navigation.py
@@ -1,0 +1,138 @@
+from unittest.mock import MagicMock
+
+from flask import Flask, session
+
+import potato.routes as routes
+from potato.user_state_management import UserStateManager
+from potato.phase import UserPhase
+
+
+def _make_usm_config():
+    return {
+        "output_annotation_dir": ".",
+        "annotation_task_name": "Phase Flow Test",
+        "annotation_schemes": [],
+        "phases": {
+            "order": ["consent", "instructions", "annotation", "poststudy"],
+            "consent": {"type": "consent"},
+            "instructions": {"type": "instructions"},
+            "poststudy": {"type": "poststudy"},
+        },
+    }
+
+
+def _build_routes_app():
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.add_url_rule("/", "home", lambda: "home")
+    return app
+
+
+class _StubPhaseUserState:
+    def __init__(self, phase):
+        self._phase = phase
+
+    def get_phase(self):
+        return self._phase
+
+
+class _StubAnnotationUserState:
+    current_instance_index = 0
+
+    def get_phase(self):
+        return UserPhase.ANNOTATION
+
+    def has_assignments(self):
+        return True
+
+    def has_remaining_assignments(self):
+        return True
+
+    def get_current_instance_index(self):
+        return self.current_instance_index
+
+
+def test_get_prev_user_phase_page_returns_previous_page_within_same_phase():
+    usm = UserStateManager(_make_usm_config())
+    usm.phase_type_to_name_to_page = {
+        UserPhase.CONSENT: {"consent_page": "consent.html"},
+        UserPhase.INSTRUCTIONS: {
+            "instructions_a": "instructions_a.html",
+            "instructions_b": "instructions_b.html",
+        },
+        UserPhase.POSTSTUDY: {"poststudy_page": "poststudy.html"},
+    }
+
+    user_state = MagicMock()
+    user_state.get_current_phase_and_page.return_value = (UserPhase.INSTRUCTIONS, "instructions_b")
+    usm.user_to_annotation_state["user1"] = user_state
+
+    assert usm.get_prev_user_phase_page("user1") == (UserPhase.INSTRUCTIONS, "instructions_a")
+
+
+def test_get_prev_user_phase_page_returns_previous_phase_boundary():
+    usm = UserStateManager(_make_usm_config())
+    usm.phase_type_to_name_to_page = {
+        UserPhase.CONSENT: {"consent_page": "consent.html"},
+        UserPhase.INSTRUCTIONS: {
+            "instructions_a": "instructions_a.html",
+            "instructions_b": "instructions_b.html",
+        },
+        UserPhase.POSTSTUDY: {"poststudy_page": "poststudy.html"},
+    }
+
+    user_state = MagicMock()
+    user_state.get_current_phase_and_page.return_value = (UserPhase.ANNOTATION, None)
+    usm.user_to_annotation_state["user1"] = user_state
+
+    assert usm.get_prev_user_phase_page("user1") == (UserPhase.INSTRUCTIONS, "instructions_b")
+
+
+def test_annotate_prev_instance_on_non_annotation_phase_retreats(monkeypatch):
+    app = _build_routes_app()
+    retreat_calls = []
+
+    usm = MagicMock()
+    usm.has_user.return_value = True
+    usm.get_user_ids.return_value = ["user1"]
+    usm.retreat_phase.side_effect = lambda username: retreat_calls.append(username)
+
+    monkeypatch.setattr(routes, "app", app, raising=False)
+    monkeypatch.setattr(routes, "config", {"debug": False}, raising=False)
+    monkeypatch.setattr(routes, "get_user_state_manager", lambda: usm)
+    monkeypatch.setattr(routes, "get_user_state", lambda username: _StubPhaseUserState(UserPhase.INSTRUCTIONS))
+
+    with app.test_request_context("/annotate", method="POST", json={"action": "prev_instance"}):
+        session["username"] = "user1"
+        response = routes.annotate()
+
+    assert response.status_code == 302
+    assert response.location.endswith("/")
+    assert retreat_calls == ["user1"]
+
+
+def test_annotate_prev_instance_from_first_annotation_item_retreats(monkeypatch):
+    app = _build_routes_app()
+    retreat_calls = []
+
+    user_state = _StubAnnotationUserState()
+    usm = MagicMock()
+    usm.has_user.return_value = True
+    usm.get_user_ids.return_value = ["user1"]
+    usm.retreat_phase.side_effect = lambda username: retreat_calls.append(username)
+
+    monkeypatch.setattr(routes, "app", app, raising=False)
+    monkeypatch.setattr(routes, "config", {"debug": False}, raising=False)
+    monkeypatch.setattr(routes, "get_user_state_manager", lambda: usm)
+    monkeypatch.setattr(routes, "get_user_state", lambda username: user_state)
+    monkeypatch.setattr(routes, "move_to_prev_instance", lambda username: False)
+    monkeypatch.setattr(routes, "_inject_quality_control_item_if_needed", lambda username, state: None)
+    monkeypatch.setattr(routes, "get_ai_cache_manager", lambda: None)
+
+    with app.test_request_context("/annotate", method="POST", json={"action": "prev_instance"}):
+        session["username"] = "user1"
+        response = routes.annotate()
+
+    assert response.status_code == 302
+    assert response.location.endswith("/")
+    assert retreat_calls == ["user1"]

--- a/tests/unit/test_phase_page_restoration.py
+++ b/tests/unit/test_phase_page_restoration.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+from flask import Flask
+
+import potato.flask_server as fs
+from potato.item_state_management import Label
+from potato.phase import UserPhase
+
+
+def test_get_current_page_html_restores_saved_phase_answers(monkeypatch):
+    template_dir = Path(__file__).resolve().parent / "phase_page_templates"
+    app = Flask(__name__, template_folder=str(template_dir))
+    app.secret_key = "test-secret"
+
+    class StubUserState:
+        def __init__(self):
+            self.phase_to_page_to_label_to_value = {
+                UserPhase.PRESTUDY: {
+                    "survey_page": {
+                        Label("radio_schema", "choice"): "yes",
+                        Label("checkbox_schema", "selected"): True,
+                        Label("text_schema", "comment"): "Saved text",
+                        Label("number_schema", "count"): 7,
+                        Label("textarea_schema", "notes"): "Saved notes",
+                        Label("select_schema", "pick"): "b",
+                    }
+                }
+            }
+
+        def get_current_phase_and_page(self):
+            return (UserPhase.PRESTUDY, "survey_page")
+
+        def get_assigned_instance_count(self):
+            return 0
+
+    class StubUSM:
+        def get_phase_html_fname(self, phase, page):
+            return "survey_page.html"
+
+    monkeypatch.setattr(fs, "app", app, raising=False)
+    monkeypatch.setattr(fs, "get_user_state", lambda username: StubUserState())
+    monkeypatch.setattr(fs, "get_user_state_manager", lambda: StubUSM())
+
+    with app.test_request_context("/"):
+        html = fs.get_current_page_html({"annotation_task_name": "Survey Test"}, "user1")
+
+    soup = BeautifulSoup(html, "html.parser")
+
+    assert soup.find("input", {"name": "radio_schema:::choice", "value": "yes"}).has_attr("checked")
+    assert soup.find("input", {"name": "checkbox_schema:::selected"}).has_attr("checked")
+    assert soup.find("input", {"name": "text_schema:::comment"})["value"] == "Saved text"
+    assert soup.find("input", {"name": "number_schema:::count"})["value"] == "7"
+    assert soup.find("textarea", {"name": "textarea_schema:::notes"}).text == "Saved notes"
+    assert soup.find("select", {"name": "select_schema:::pick"}).find("option", {"value": "b"}).has_attr("selected")


### PR DESCRIPTION
﻿This pull request fixes two remaining workflow issues in phase-based and surveyflow-style studies.

While testing multi-phase study flows locally, two usability problems remained even after the earlier header/codebook regression was addressed. First, back navigation was inconsistent across phase boundaries. Non-annotation pages could leak `prev_instance` requests into `/annotate`, and the annotation back path had no fallback when the user was already on the first assigned annotation item. In practice, that meant users could move forward through surveyflow pages but could not reliably move backward from annotation into the previous configured surveyflow page.

The root cause was that the navigation logic only knew how to move backward within annotation-instance ordering. There was no reverse phase/page traversal companion to the existing forward phase sequencing, so the server had no way to retreat from annotation into the previous configured phase or to step backward within a multi-page non-annotation phase.

This change adds reverse workflow traversal to `UserStateManager` via `get_prev_user_phase_page()` and `retreat_phase()`. The `/annotate` route now uses that path in two places: when a leaked `prev_instance` arrives from a non-annotation phase, and when an annotation user presses Back on their first assigned item and instance-level navigation cannot move any farther. In both cases, the user is moved to the previous configured page or phase instead of being stranded.

The second issue was state restoration for phase pages. Surveyflow answers were already being persisted into `phase_to_page_to_label_to_value`, but when users revisited a non-annotation page the saved values were not rehydrated into the rendered form. That made previously saved answers, especially free-text fields, appear blank even though the data was still present in user state.

The fix updates `get_current_page_html()` to mirror the same restore-before-serve behavior used elsewhere in the app. After rendering the phase page template, the server parses the HTML, looks up saved values for the current phase/page, and reapplies them to matching radio buttons, checkboxes, text inputs, number inputs, textareas, and select elements before returning the page.

Together, these changes make phase-based workflows behave like a coherent multi-step study: the Back button now traverses surveyflow and annotation boundaries correctly, and previously entered surveyflow answers reappear when users revisit earlier pages.

Validation used for this change:

- `..\venv\Scripts\python.exe -m pytest tests\unit\test_phase_flow_navigation.py tests\unit\test_phase_page_restoration.py tests\unit\test_leaked_nav_guard.py -q`
