### PR TITLE
Enhance user assignment checks and handle dataset updates

### DIFF
--- a/potato/database/mysql_user_state.py
+++ b/potato/database/mysql_user_state.py
@@ -462,9 +462,14 @@ class MysqlUserState(UserState):
 
     def has_remaining_assignments(self) -> bool:
         """Check if the user has remaining assignments."""
-        if self.max_assignments < 0:
-            return True
-        return self.get_annotation_count() < self.max_assignments
+        from potato.item_state_management import get_item_state_manager
+
+        has_available_items = get_item_state_manager().has_unlabeled_items_for_user(self)
+
+        if self.max_assignments >= 0:
+            return self.get_annotation_count() < self.max_assignments and has_available_items
+
+        return has_available_items
 
     def set_max_assignments(self, max_assignments: int) -> None:
         """Set the maximum number of assignments."""

--- a/potato/routes.py
+++ b/potato/routes.py
@@ -4046,12 +4046,27 @@ def update_instance():
             logger.error(f"User state not found for user: {username}")
             return jsonify({"status": "error", "message": "User state not found"})
 
-        # Guard: reject updates for instances not assigned to this user
-        if user_state.get_phase() == UserPhase.ANNOTATION:
+        # Synthetic phase-page saves use a sentinel instance ID from annotation.js.
+        # They should be routed by the current user phase instead of assignment checks.
+        is_phase_page_update = instance_id == "__phase_page__"
+
+        # Guard: reject updates for instances not assigned to this user.
+        # Skip this for synthetic phase-page updates so non-annotation page autosaves
+        # do not get treated like dataset item writes.
+        if user_state.get_phase() == UserPhase.ANNOTATION and not is_phase_page_update:
             assigned_ids = user_state.get_assigned_instance_ids()
             if assigned_ids and instance_id not in assigned_ids:
                 logger.warning(f"User {username} tried to update unassigned instance {instance_id}")
                 return jsonify({"status": "error", "message": "Instance not assigned to user"})
+
+        # If a synthetic phase-page save arrives while the backend still thinks the user
+        # is in annotation, acknowledge it without writing item state. This avoids a
+        # noisy warning/error path during end-of-annotation transitions.
+        if user_state.get_phase() == UserPhase.ANNOTATION and is_phase_page_update:
+            logger.info(
+                f"Ignoring synthetic phase-page update for user {username} while still in annotation phase"
+            )
+            return jsonify({"status": "ok", "message": "Ignored synthetic phase-page update"})
 
         # Debug: Log user phase for debugging annotation storage issues
         logger.debug(f"User '{username}' phase: {user_state.get_phase()}, current_phase_and_page: {user_state.current_phase_and_page}")

--- a/potato/user_state_management.py
+++ b/potato/user_state_management.py
@@ -2182,12 +2182,16 @@ class InMemoryUserState(UserState):
 
     def has_remaining_assignments(self) -> bool:
         """Returns True if the user has any remaining instances to annotate."""
-        if self.max_assignments >= 0:
-            # Explicit cap: user must annotate exactly this many items
-            return len(self.get_annotated_instance_ids()) < self.max_assignments
-        # Unlimited: check if there are actually items left in the dataset
         from potato.item_state_management import get_item_state_manager
-        return get_item_state_manager().has_unlabeled_items_for_user(self)
+
+        has_available_items = get_item_state_manager().has_unlabeled_items_for_user(self)
+
+        if self.max_assignments >= 0:
+            # Explicit cap: the user may annotate up to this many items, but should
+            # still finish cleanly if the dataset/eligible pool is exhausted first.
+            return len(self.get_annotated_instance_ids()) < self.max_assignments and has_available_items
+
+        return has_available_items
 
     def find_next_unannotated_index(self) -> Optional[int]:
         """


### PR DESCRIPTION
This PR exists because the progression bug was still occurring after the earlier fix in https://github.com/davidjurgens/potato/commit/c8ea49e8c2a332673f70032540b992aba237bd23 when a user finished their final available annotation item, the session could still get stuck instead of advancing cleanly to the next configured phase or the end state.

---

## Root Cause

The root cause turned out to be a second layer of “remaining work” logic.

The earlier upstream change fixed the unlimited-assignment case by checking whether unlabeled items actually existed. However, in this fork, users can also have an explicit `max_annotations_per_user` cap, and the code was still interpreting that cap too literally.

If a user had `max_assignments = 20`, but only 3 eligible items actually existed for that user, `has_remaining_assignments()` would continue to return `True` simply because `3 < 20`.

This caused the system to believe the user still had work left, even though:
- The assignment pool was exhausted, and
- The backend was already logging: `No unlabeled items available for user ...`

In practice, this created a stuck end-of-annotation state:
- The app could not assign more items, and
- It would not advance phases because the user was still considered to have “remaining assignments.”

---

## Fix: Remaining Assignment Logic

This PR updates the remaining-assignment check to account for **both** conditions:

- Whether the user is still below their configured assignment cap.
- Whether there are actually eligible unlabeled items left for that specific user.

This distinction matters because an assignment cap is only an upper bound, not a guarantee that enough items exist to satisfy it.

If the dataset, annotation-per-item cap, attention-check injection, prior annotations, or other eligibility rules exhaust the pool first, the user should still be allowed to finish cleanly.

The previous logic handled the cap but ignored real availability, which is why the bug persisted.

---

## Fix: `__phase_page__` Autosave Handling

This PR also fixes an issue with phase-page autosaves involving the synthetic `__phase_page__` instance ID.

### Background

The frontend uses this sentinel on non-annotation pages to reuse the same save pipeline for:
- Consent
- Instructions
- Prestudy forms
- Poststudy forms

However, the backend route `/updateinstance` was still applying normal annotation-item assignment validation to this sentinel in some transition windows.

This led to warnings such as:

`User X tried to update unassigned instance phase_page`


While not the primary cause of the stuck state, this contributed to inconsistent transition behavior and made debugging more difficult.

---

## Updated Behavior

The route logic now treats `__phase_page__` as a synthetic phase-page save rather than an annotation item:

- If a real annotation item is being updated during annotation, assignment validation still applies.
- If the sentinel `__phase_page__` is posted, it is no longer treated as an unassigned item.
- If such a sentinel arrives while the backend still considers the user to be in annotation, it is acknowledged and ignored rather than rejected.

This distinction is necessary because:
- Phase-page persistence and annotation-item persistence are conceptually different operations.
- They should not share validation rules, even if they share client-side infrastructure.

Without this separation, valid phase-form saves can be misclassified as invalid annotation updates during phase transitions.

---

## Consistency Across Backends

The remaining-assignment fix has been applied to:
- In-memory user state
- MySQL-backed user state

This ensures consistent behavior across storage backends and avoids fixing the bug in only one deployment mode.