### PR TITLE
Implement phase page ordering and add corresponding tests

### DIFF
--- a/potato/user_state_management.py
+++ b/potato/user_state_management.py
@@ -543,10 +543,69 @@ class UserStateManager:
         """Return cached page ordering for a phase."""
         self._ensure_phase_caches()
         if phase not in self._phase_page_order_cache:
-            pages = tuple(self.phase_type_to_name_to_page.get(phase, {}).keys())
+            pages = self._get_phase_pages_from_config_order(phase)
             self._phase_page_order_cache[phase] = pages
             self._phase_page_index_cache[phase] = {page: i for i, page in enumerate(pages)}
         return self._phase_page_order_cache[phase]
+
+    def _get_phase_pages_from_config_order(self, phase: UserPhase) -> tuple[str, ...]:
+        """
+        Derive page ordering for a phase from config when possible.
+
+        This avoids depending on internal registration order, which can drift
+        from the config order when phases are loaded through different paths.
+        """
+        registered_pages = self.phase_type_to_name_to_page.get(phase, {})
+        if not registered_pages:
+            return tuple()
+
+        phases_config = self.config.get("phases")
+        configured_pages: list[str] = []
+
+        if isinstance(phases_config, list):
+            for phase_config in phases_config:
+                if not isinstance(phase_config, dict):
+                    continue
+                phase_name = phase_config.get("name")
+                phase_type_name = phase_config.get("type")
+                if not phase_name or not phase_type_name:
+                    continue
+                try:
+                    phase_type = UserPhase.fromstr(phase_type_name)
+                except ValueError:
+                    continue
+                if phase_type == phase and phase_name in registered_pages:
+                    configured_pages.append(phase_name)
+        elif isinstance(phases_config, dict):
+            phase_order = phases_config.get("order")
+            if not isinstance(phase_order, list):
+                phase_order = [name for name in phases_config.keys() if name != "order"]
+
+            for phase_name in phase_order:
+                if phase_name == "annotation":
+                    continue
+                phase_config = phases_config.get(phase_name)
+                if not isinstance(phase_config, dict):
+                    continue
+                phase_type_name = phase_config.get("type")
+                if not phase_type_name:
+                    continue
+                try:
+                    phase_type = UserPhase.fromstr(phase_type_name)
+                except ValueError:
+                    continue
+                if phase_type == phase and phase_name in registered_pages:
+                    configured_pages.append(phase_name)
+
+        if not configured_pages:
+            return tuple(registered_pages.keys())
+
+        # Keep any registered pages that were not represented in config order.
+        for page_name in registered_pages.keys():
+            if page_name not in configured_pages:
+                configured_pages.append(page_name)
+
+        return tuple(configured_pages)
 
     def add_user(self, user_id: str) -> UserState:
         """

--- a/tests/unit/test_phase_page_order_from_config.py
+++ b/tests/unit/test_phase_page_order_from_config.py
@@ -1,0 +1,25 @@
+from potato.phase import UserPhase
+from potato.user_state_management import UserStateManager
+
+
+def test_phase_pages_follow_config_order_even_if_registered_in_reverse():
+    config = {
+        "output_annotation_dir": ".",
+        "phases": {
+            "order": ["prestudy_intro", "prestudy_questions", "annotation"],
+            "prestudy_intro": {"type": "prestudy", "file": "intro.json"},
+            "prestudy_questions": {"type": "prestudy", "file": "questions.json"},
+            "annotation": {"type": "annotation"},
+        },
+    }
+
+    usm = UserStateManager(config)
+
+    # Simulate pages being registered in the wrong order by a loader path.
+    usm.add_phase(UserPhase.PRESTUDY, "prestudy_questions", "questions.html")
+    usm.add_phase(UserPhase.PRESTUDY, "prestudy_intro", "intro.html")
+
+    assert usm._get_phase_pages(UserPhase.PRESTUDY) == (
+        "prestudy_intro",
+        "prestudy_questions",
+    )


### PR DESCRIPTION
## Summary

This PR fixes an intermittent phase ordering bug where multi-page survey phases could render in the wrong order, causing the last page of a phase like `prestudy` to appear first.

The root issue was that intra-phase page navigation depended on internal phase registration order rather than the order declared in the config. In cases where registration order drifted, navigation could become effectively reversed even though the config itself was correct.

## What Changed

- Updated phase page ordering logic to derive page order from the configured phase order whenever possible
- Kept a safe fallback to registration order for pages not explicitly represented in config
- Added a regression test covering the case where pages are registered in reverse order but must still follow config order

## Why This Matters

This bug was especially tricky because it appeared nondeterministic across machines and projects. By making config order the source of truth, phase navigation is now deterministic and aligned with what users specify in the YAML.

## Notes

This change is intentionally narrow as it hardens page sequencing without changing the broader phase model or config format.