### PR TITLE
Reclaim abandoned annotation assignments for Prolific and QC-blocked workers

### DIFF
--- a/docs/advanced/task_assignment.md
+++ b/docs/advanced/task_assignment.md
@@ -165,6 +165,23 @@ assignment:
 | `max_annotations_per_item` | integer | Target annotations per item (-1 = unlimited) |
 | `assignment.random_seed` | integer | Seed for reproducible random assignment |
 
+### Reclaiming Abandoned Assignments
+
+For crowdsourcing batches, workers can return, time out, or fail quality checks after
+receiving a batch of assigned items. Potato reclaims assigned-but-unannotated items
+so they can be assigned again. Completed annotations are kept.
+
+```yaml
+instance_reclaim:
+  enabled: true
+  timeout_hours: 24
+```
+
+Reclaiming happens automatically for stale assignments when assignment runs, and for
+Prolific workers whose submissions become `RETURNED`, `TIMED-OUT`, or `REJECTED`
+when Prolific submission status is refreshed. Users blocked by attention-check
+failure also release their unannotated assignments immediately.
+
 ---
 
 ## Legacy Configuration

--- a/docs/deployment/crowdsourcing.md
+++ b/docs/deployment/crowdsourcing.md
@@ -150,6 +150,11 @@ For larger studies, Potato can integrate with Prolific's API to automatically ma
 - Resume when load decreases
 - Automatically pause when the study is complete
 
+When Prolific submission status is refreshed, Potato also releases any
+assigned-but-unannotated items from workers whose submissions are `RETURNED`,
+`TIMED-OUT`, or `REJECTED`, so abandoned batches can be assigned to other workers.
+Annotations already completed by those workers are preserved.
+
 ### Setup Prolific API
 
 1. **Get your Prolific API token** from your [Prolific account settings](https://app.prolific.com/account/general)

--- a/potato/database/mysql_user_state.py
+++ b/potato/database/mysql_user_state.py
@@ -130,6 +130,53 @@ class MysqlUserState(UserState):
 
         self._invalidate_cache()
 
+    def unassign_instance(self, instance_id: str) -> bool:
+        """Remove an instance assignment from the user."""
+        with self.db_manager.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT assignment_order FROM user_instance_assignments
+                WHERE user_id = %s AND instance_id = %s
+            """, (self.user_id, instance_id))
+            result = cursor.fetchone()
+            if result is None:
+                return False
+
+            removed_order = result[0]
+            cursor.execute("""
+                DELETE FROM user_instance_assignments
+                WHERE user_id = %s AND instance_id = %s
+            """, (self.user_id, instance_id))
+            cursor.execute("""
+                UPDATE user_instance_assignments
+                SET assignment_order = assignment_order - 1
+                WHERE user_id = %s AND assignment_order > %s
+            """, (self.user_id, removed_order))
+
+            current_index = self.get_current_instance_index()
+            cursor.execute("""
+                SELECT COUNT(*) FROM user_instance_assignments WHERE user_id = %s
+            """, (self.user_id,))
+            count_result = cursor.fetchone()
+            assignment_count = count_result[0] if count_result is not None else 0
+
+            if assignment_count == 0:
+                new_index = -1
+            elif current_index > removed_order:
+                new_index = current_index - 1
+            elif current_index == removed_order:
+                new_index = min(removed_order, assignment_count - 1)
+            else:
+                new_index = min(current_index, assignment_count - 1)
+
+            cursor.execute("""
+                UPDATE user_states SET current_instance_index = %s WHERE user_id = %s
+            """, (new_index, self.user_id))
+            conn.commit()
+
+        self._invalidate_cache()
+        return True
+
     def get_current_instance(self) -> Optional[Item]:
         """Get the current instance the user is annotating."""
         current_index = self.get_current_instance_index()
@@ -454,6 +501,28 @@ class MysqlUserState(UserState):
             cursor.execute("DELETE FROM phase_annotations WHERE user_id = %s", (self.user_id,))
             cursor.execute("DELETE FROM behavioral_data WHERE user_id = %s", (self.user_id,))
             cursor.execute("DELETE FROM ai_hints WHERE user_id = %s", (self.user_id,))
+            conn.commit()
+
+    def clear_instance_annotations(self, instance_id: str) -> None:
+        """Clear all annotations for one instance."""
+        with self.db_manager.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "DELETE FROM label_annotations WHERE user_id = %s AND instance_id = %s",
+                (self.user_id, instance_id),
+            )
+            cursor.execute(
+                "DELETE FROM span_annotations WHERE user_id = %s AND instance_id = %s",
+                (self.user_id, instance_id),
+            )
+            cursor.execute(
+                "DELETE FROM behavioral_data WHERE user_id = %s AND instance_id = %s",
+                (self.user_id, instance_id),
+            )
+            cursor.execute(
+                "DELETE FROM ai_hints WHERE user_id = %s AND instance_id = %s",
+                (self.user_id, instance_id),
+            )
             conn.commit()
 
     def has_assignments(self) -> bool:

--- a/potato/item_state_management.py
+++ b/potato/item_state_management.py
@@ -1517,31 +1517,110 @@ class ItemStateManager:
                 self.logger.info(f"Reclaiming stale instance {iid} from user {username} "
                                  f"(assigned {(time.time() - timestamp)/3600:.1f} hours ago)")
 
-                # Remove from user's assignment
+                reclaimed = False
                 if user_state:
-                    assigned_ids = user_state.get_assigned_instance_ids()
-                    if iid in assigned_ids:
-                        assigned_ids.discard(iid)
-                        if iid in user_state.instance_id_ordering:
-                            user_state.instance_id_ordering.remove(iid)
+                    reclaimed = self._reclaim_unannotated_assignment(
+                        user_state,
+                        iid,
+                        reason="stale_assignment",
+                    )
+                else:
+                    if iid not in self.completed_instance_ids and iid not in self.remaining_instance_ids:
+                        self.remaining_instance_ids.append(iid)
+                    self.instance_annotators[iid].discard(username)
+                    if iid in self.assignment_timestamps:
+                        self.assignment_timestamps[iid].pop(username, None)
+                    reclaimed = True
 
-                # Return to pool if not already there and not completed
-                if iid not in self.completed_instance_ids and iid not in self.remaining_instance_ids:
-                    self.remaining_instance_ids.append(iid)
-
-                # Remove annotator tracking
-                self.instance_annotators[iid].discard(username)
-
-                # Clean up timestamp
-                del self.assignment_timestamps[iid][username]
-                reclaimed_count += 1
+                if reclaimed:
+                    reclaimed_count += 1
 
             # Clean up empty entries
-            if not self.assignment_timestamps[iid]:
+            if iid in self.assignment_timestamps and not self.assignment_timestamps[iid]:
                 del self.assignment_timestamps[iid]
 
         if reclaimed_count > 0:
             self.logger.info(f"Reclaimed {reclaimed_count} stale instance assignments")
+
+    def _reclaim_unannotated_assignment(
+        self,
+        user_state: 'UserState',
+        instance_id: str,
+        reason: str = "assignment_reclaim",
+    ) -> bool:
+        """Reclaim one unannotated assignment from a user."""
+        user_id = getattr(user_state, 'user_id', None) or user_state.get_user_id()
+
+        if user_state.has_annotated(instance_id):
+            return False
+
+        unassigned = user_state.unassign_instance(instance_id)
+        if not unassigned:
+            return False
+
+        if instance_id not in self.completed_instance_ids and instance_id not in self.remaining_instance_ids:
+            self.remaining_instance_ids.append(instance_id)
+
+        self.instance_annotators[instance_id].discard(user_id)
+        if instance_id in self.assignment_timestamps:
+            self.assignment_timestamps[instance_id].pop(user_id, None)
+            if not self.assignment_timestamps[instance_id]:
+                del self.assignment_timestamps[instance_id]
+
+        self.logger.info(
+            "Reclaimed unannotated assignment %s from user %s (%s)",
+            instance_id,
+            user_id,
+            reason,
+        )
+        return True
+
+    def reclaim_unannotated_assignments_for_user(
+        self,
+        user_state: 'UserState',
+        reason: str = "assignment_reclaim",
+    ) -> List[str]:
+        """Reclaim all assigned-but-unannotated instances for a user."""
+        reclaimed = []
+        with self._lock:
+            for instance_id in list(user_state.get_assigned_instance_ids()):
+                if self._reclaim_unannotated_assignment(user_state, instance_id, reason):
+                    reclaimed.append(instance_id)
+        return reclaimed
+
+    def reclaim_unannotated_assignments_for_users(
+        self,
+        user_ids: List[str],
+        reason: str = "assignment_reclaim",
+    ) -> Dict[str, List[str]]:
+        """Reclaim assigned-but-unannotated instances for several users."""
+        from potato.user_state_management import get_user_state_manager
+
+        usm = get_user_state_manager()
+        reclaimed_by_user = {}
+        for user_id in user_ids:
+            user_state = usm.get_user_state(user_id)
+            if not user_state:
+                continue
+
+            reclaimed = self.reclaim_unannotated_assignments_for_user(
+                user_state,
+                reason=reason,
+            )
+            if not reclaimed:
+                continue
+
+            reclaimed_by_user[user_id] = reclaimed
+            try:
+                usm.save_user_state(user_state)
+            except Exception as e:
+                self.logger.warning(
+                    "Could not persist reclaimed assignments for user %s: %s",
+                    user_id,
+                    e,
+                )
+
+        return reclaimed_by_user
 
     def _maybe_assign_icl_verification(self, user_state: 'UserState') -> int:
         """

--- a/potato/routes.py
+++ b/potato/routes.py
@@ -140,6 +140,31 @@ def _inject_quality_control_item_if_needed(username, user_state):
             return
 
 
+def _reclaim_blocked_user_assignments(username, user_state, current_instance_id=None):
+    """Release unannotated assignments after a user is blocked."""
+    if current_instance_id and hasattr(user_state, "clear_instance_annotations"):
+        user_state.clear_instance_annotations(current_instance_id)
+
+    reclaimed = get_item_state_manager().reclaim_unannotated_assignments_for_user(
+        user_state,
+        reason="quality_control_block",
+    )
+
+    if reclaimed:
+        logger.info(
+            "Reclaimed %d unannotated assignments from blocked user %s",
+            len(reclaimed),
+            username,
+        )
+
+    try:
+        get_user_state_manager().save_user_state(user_state)
+    except Exception as e:
+        logger.warning("Could not persist blocked-user assignment reclaim for %s: %s", username, e)
+
+    return reclaimed
+
+
 def get_debug_phase_target(debug_phase: str) -> tuple:
     """
     Parse the debug_phase string and find the matching phase and page.
@@ -2775,21 +2800,15 @@ def admin_api_reclaim_instance():
     if user_state.has_annotated(iid):
         return jsonify({"error": "Cannot reclaim: user has already annotated this instance"}), 400
 
-    # Remove from user's assignment
-    assigned_ids = user_state.get_assigned_instance_ids()
-    if iid in assigned_ids:
-        assigned_ids.discard(iid)
-        if iid in user_state.instance_id_ordering:
-            user_state.instance_id_ordering.remove(iid)
+    reclaimed = ism._reclaim_unannotated_assignment(
+        user_state,
+        iid,
+        reason="manual_admin_reclaim",
+    )
+    if not reclaimed:
+        return jsonify({"error": "Instance is not assigned to this user"}), 400
 
-    # Return to pool
-    if iid not in ism.completed_instance_ids and iid not in ism.remaining_instance_ids:
-        ism.remaining_instance_ids.append(iid)
-
-    # Clean up tracking
-    ism.instance_annotators[iid].discard(username)
-    if iid in ism.assignment_timestamps and username in ism.assignment_timestamps[iid]:
-        del ism.assignment_timestamps[iid][username]
+    get_user_state_manager().save_user_state(user_state)
 
     return jsonify({"success": True, "instance_id": iid, "username": username})
 
@@ -4514,6 +4533,11 @@ def update_instance():
                 # Handle blocking
                 if attention_result.get("blocked"):
                     logger.warning(f"User {username} blocked by attention check")
+                    reclaimed = _reclaim_blocked_user_assignments(
+                        username,
+                        user_state,
+                        current_instance_id=instance_id,
+                    )
 
                     # Emit webhook for attention check failure
                     from potato.webhooks import get_webhook_emitter
@@ -4533,11 +4557,11 @@ def update_instance():
                             ),
                         )
 
-                    # Don't save state for blocked user
                     return jsonify({
                         "status": "blocked",
                         "message": attention_result.get("message", "You have been blocked."),
-                        "qc_result": qc_result
+                        "qc_result": qc_result,
+                        "reclaimed_assignments": reclaimed,
                     })
             else:
                 # Check if this is a gold standard

--- a/potato/server_utils/prolific_apis.py
+++ b/potato/server_utils/prolific_apis.py
@@ -24,6 +24,7 @@ import requests
 from collections import OrderedDict, defaultdict
 import time
 import json
+import logging
 
 # The base wrapper of prolific apis
 class ProlificBase(object):
@@ -372,6 +373,7 @@ class ProlificStudy(ProlificBase):
             self.sessions[v['id']] = v
             #self.user2session[v['participant_id']] = v['id']
             self.user_status_dict[v['status']].add(v['participant_id'])
+        self.reclaim_dropped_user_assignments()
 
     def get_dropped_users(self):
         """
@@ -381,6 +383,32 @@ class ProlificStudy(ProlificBase):
             list: Participant IDs who have returned, timed out, or been rejected
         """
         return list(self.user_status_dict['RETURNED'] | self.user_status_dict['TIMED-OUT'] | self.user_status_dict['REJECTED'])
+
+    def reclaim_dropped_user_assignments(self):
+        """
+        Release unannotated Potato assignments for dropped Prolific workers.
+
+        Prolific reports dropped workers as RETURNED, TIMED-OUT, or REJECTED.
+        Their participant IDs are also the Potato usernames for url-direct
+        Prolific login, so the item state manager can safely reclaim any
+        assigned-but-unannotated instances.
+        """
+        dropped_users = self.get_dropped_users()
+        if not dropped_users:
+            return {}
+
+        try:
+            from potato.item_state_management import get_item_state_manager
+            return get_item_state_manager().reclaim_unannotated_assignments_for_users(
+                dropped_users,
+                reason="prolific_dropped",
+            )
+        except Exception as e:
+            logging.getLogger(__name__).warning(
+                "Could not reclaim assignments for dropped Prolific users: %s",
+                e,
+            )
+            return {}
 
     def get_concurrent_sessions_count(self):
         """

--- a/potato/user_state_management.py
+++ b/potato/user_state_management.py
@@ -1085,6 +1085,9 @@ class UserState:
     def assign_instance(self, item: Item) -> None:
         raise NotImplementedError()
 
+    def unassign_instance(self, instance_id: str) -> bool:
+        raise NotImplementedError()
+
     def get_current_instance(self) -> Item:
         raise NotImplementedError()
 
@@ -1903,6 +1906,36 @@ class InMemoryUserState(UserState):
         if self.current_instance_index == -1:
             self.current_instance_index = 0
 
+    def unassign_instance(self, instance_id: str) -> bool:
+        """Remove an uncompleted assignment from this user."""
+        if instance_id not in self.assigned_instance_ids and instance_id not in self.instance_id_ordering:
+            return False
+
+        old_index = self.current_instance_index
+        try:
+            removed_index = self.instance_id_ordering.index(instance_id)
+        except ValueError:
+            removed_index = None
+
+        self.assigned_instance_ids.discard(instance_id)
+        self.instance_id_ordering = [
+            iid for iid in self.instance_id_ordering if iid != instance_id
+        ]
+        self.instance_id_to_order = self.generate_id_order_mapping(self.instance_id_ordering)
+
+        if not self.instance_id_ordering:
+            self.current_instance_index = -1
+        elif removed_index is None:
+            self.current_instance_index = min(max(old_index, 0), len(self.instance_id_ordering) - 1)
+        elif old_index > removed_index:
+            self.current_instance_index = max(0, old_index - 1)
+        elif old_index == removed_index:
+            self.current_instance_index = min(removed_index, len(self.instance_id_ordering) - 1)
+        else:
+            self.current_instance_index = min(old_index, len(self.instance_id_ordering) - 1)
+
+        return True
+
     def get_current_phase_and_page(self) -> tuple[UserPhase, str]:
         return self.current_phase_and_page
 
@@ -2292,6 +2325,15 @@ class InMemoryUserState(UserState):
         self.instance_id_to_event_to_value.clear()
         self.instance_id_to_behavioral_data.clear()
         self.ai_hints.clear()
+
+    def clear_instance_annotations(self, instance_id: str) -> None:
+        """Clear all annotation state for one instance."""
+        self.instance_id_to_label_to_value.pop(instance_id, None)
+        self.instance_id_to_span_to_value.pop(instance_id, None)
+        self.instance_id_to_link_to_value.pop(instance_id, None)
+        self.instance_id_to_event_to_value.pop(instance_id, None)
+        self.instance_id_to_behavioral_data.pop(instance_id, None)
+        self.ai_hints.pop(instance_id, None)
 
     def has_remaining_assignments(self) -> bool:
         """Returns True if the user has any remaining instances to annotate."""

--- a/tests/unit/test_assignment_reclaim.py
+++ b/tests/unit/test_assignment_reclaim.py
@@ -1,0 +1,146 @@
+import time
+
+from potato.item_state_management import Item, ItemStateManager, Label
+from potato.user_state_management import InMemoryUserState, UserPhase
+from potato.server_utils.prolific_apis import ProlificStudy
+
+
+def _manager_with_items():
+    manager = ItemStateManager(
+        {
+            "assignment_strategy": "fixed_order",
+            "max_annotations_per_item": 1,
+            "instance_reclaim": {"enabled": True, "timeout_hours": 1},
+        }
+    )
+    manager.add_items(
+        {
+            "item_1": {"id": "item_1", "text": "one"},
+            "item_2": {"id": "item_2", "text": "two"},
+            "item_3": {"id": "item_3", "text": "three"},
+        }
+    )
+    return manager
+
+
+def test_unassign_instance_keeps_assignment_indexes_consistent():
+    user = InMemoryUserState("worker")
+    user.assign_instance(Item("item_1", {"text": "one"}))
+    user.assign_instance(Item("item_2", {"text": "two"}))
+    user.assign_instance(Item("item_3", {"text": "three"}))
+    user.go_to_index(1)
+
+    removed = user.unassign_instance("item_2")
+
+    assert removed is True
+    assert user.get_assigned_instance_ids() == {"item_1", "item_3"}
+    assert user.instance_id_ordering == ["item_1", "item_3"]
+    assert user.instance_id_to_order == {"item_1": 0, "item_3": 1}
+    assert user.get_current_instance_index() == 1
+
+
+def test_reclaim_unannotated_assignments_keeps_completed_work():
+    manager = _manager_with_items()
+    user = InMemoryUserState("dropout")
+    user.advance_to_phase(UserPhase.ANNOTATION, None)
+    for item_id in ("item_1", "item_2", "item_3"):
+        user.assign_instance(manager.get_item(item_id))
+        manager.assignment_timestamps[item_id][user.get_user_id()] = time.time() - 7200
+
+    user.add_label_annotation("item_1", Label("sentiment", "positive"), "true")
+    manager.register_annotator("item_1", user.get_user_id())
+
+    reclaimed = manager.reclaim_unannotated_assignments_for_user(
+        user,
+        reason="test_dropout",
+    )
+
+    assert set(reclaimed) == {"item_2", "item_3"}
+    assert user.get_assigned_instance_ids() == {"item_1"}
+    assert user.instance_id_ordering == ["item_1"]
+    assert user.has_annotated("item_1") is True
+    assert "dropout" not in manager.assignment_timestamps.get("item_2", {})
+    assert "dropout" not in manager.assignment_timestamps.get("item_3", {})
+
+
+def test_stale_reclaim_removes_assignment_from_real_user_state(monkeypatch):
+    manager = _manager_with_items()
+    user = InMemoryUserState("stale_worker")
+    user.assign_instance(manager.get_item("item_1"))
+    manager.assignment_timestamps["item_1"][user.get_user_id()] = time.time() - 7200
+
+    class StubUserStateManager:
+        def get_user_state(self, user_id):
+            return user if user_id == "stale_worker" else None
+
+    monkeypatch.setattr(
+        "potato.user_state_management.get_user_state_manager",
+        lambda: StubUserStateManager(),
+    )
+
+    manager._reclaim_stale_assignments()
+
+    assert "item_1" not in user.get_assigned_instance_ids()
+    assert "item_1" not in user.instance_id_ordering
+
+
+def test_prolific_dropped_users_release_unannotated_assignments(monkeypatch):
+    manager = _manager_with_items()
+    user = InMemoryUserState("PROLIFIC_PID_1")
+    user.assign_instance(manager.get_item("item_1"))
+
+    class StubUserStateManager:
+        def get_user_state(self, user_id):
+            return user if user_id == "PROLIFIC_PID_1" else None
+
+        def save_user_state(self, user_state):
+            return None
+
+    monkeypatch.setattr(
+        "potato.user_state_management.get_user_state_manager",
+        lambda: StubUserStateManager(),
+    )
+    monkeypatch.setattr(
+        "potato.item_state_management.get_item_state_manager",
+        lambda: manager,
+    )
+
+    study = ProlificStudy.__new__(ProlificStudy)
+    study.user_status_dict = {
+        "RETURNED": {"PROLIFIC_PID_1"},
+        "TIMED-OUT": set(),
+        "REJECTED": set(),
+    }
+
+    reclaimed = study.reclaim_dropped_user_assignments()
+
+    assert reclaimed == {"PROLIFIC_PID_1": ["item_1"]}
+    assert user.get_assigned_instance_ids() == set()
+
+
+def test_quality_control_block_reclaims_batch_and_does_not_keep_failed_response(monkeypatch):
+    from potato import routes
+
+    manager = _manager_with_items()
+    user = InMemoryUserState("blocked_worker")
+    user.advance_to_phase(UserPhase.ANNOTATION, None)
+    user.assign_instance(manager.get_item("item_1"))
+    user.assign_instance(manager.get_item("item_2"))
+    user.add_label_annotation("item_2", Label("attention", "wrong"), "true")
+
+    class StubUserStateManager:
+        def save_user_state(self, user_state):
+            return None
+
+    monkeypatch.setattr(routes, "get_item_state_manager", lambda: manager)
+    monkeypatch.setattr(routes, "get_user_state_manager", lambda: StubUserStateManager())
+
+    reclaimed = routes._reclaim_blocked_user_assignments(
+        "blocked_worker",
+        user,
+        current_instance_id="item_2",
+    )
+
+    assert set(reclaimed) == {"item_1", "item_2"}
+    assert user.get_assigned_instance_ids() == set()
+    assert user.has_annotated("item_2") is False


### PR DESCRIPTION
Some people in our department requested better handling for crowdsourcing batches when workers abandon a study or fail quality checks, so I implemented automatic reclaiming of assigned-but-unannotated items.

## Summary

- Add a shared assignment reclaim path for assigned-but-unannotated instances.
- Reclaim unannotated assignments when a Prolific worker is marked `RETURNED`, `TIMED-OUT`, or `REJECTED`.
- Reclaim unannotated assignments immediately when a worker is blocked by attention-check failures.
- Preserve completed annotations while releasing only unfinished assignments.
- Fix stale assignment reclaim so it updates the real user assignment state instead of mutating a copied set.
- Add docs for abandoned assignment reclaim behavior.

## Tests

- `python -m pytest tests/unit/test_assignment_reclaim.py -q`
- `python -m pytest tests/unit/test_assignment_reclaim.py tests/unit/test_quality_control.py tests/unit/test_prolific_integration.py tests/unit/test_user_state_management.py tests/unit/test_annotation_navigation.py -q`
- `python -m pytest tests/server/test_admin_api_and_concurrency.py -q`
- `python -m compileall potato/user_state_management.py potato/item_state_management.py potato/routes.py potato/server_utils/prolific_apis.py potato/database/mysql_user_state.py`