### PR TITLE
Reclaim deep-analysis follow-ups: MySQL parity, backend bug fixes, and reclaim coverage

### DIFF
--- a/potato/database/mysql_user_state.py
+++ b/potato/database/mysql_user_state.py
@@ -24,6 +24,14 @@ class MysqlUserState(UserState):
 
     This class stores all user state data in MySQL tables, providing
     persistence and scalability for annotation workflows.
+
+    Backend feature parity gap: link annotations (SpanLink) and event
+    annotations (EventAnnotation) are only supported by InMemoryUserState.
+    The MySQL schema has no link_annotations or event_annotations tables,
+    and this class does not implement add_link_annotation /
+    add_event_annotation / get_*_annotations. Configurations that use
+    span_link or event_annotation schemas will fail with AttributeError
+    on the MySQL backend.
     """
 
     def __init__(self, user_id: str, db_manager: DatabaseManager, max_assignments: int = -1):

--- a/potato/database/mysql_user_state.py
+++ b/potato/database/mysql_user_state.py
@@ -161,6 +161,10 @@ class MysqlUserState(UserState):
                 WHERE user_id = %s AND assignment_order > %s
             """, (self.user_id, removed_order))
 
+            # get_current_instance_index opens its own connection, so under
+            # READ COMMITTED (MySQL default) it reads the pre-DELETE value,
+            # which is what the index-rebalance math below needs. The COUNT(*)
+            # that follows runs on this outer cursor and sees the DELETE.
             current_index = self.get_current_instance_index()
             cursor.execute("""
                 SELECT COUNT(*) FROM user_instance_assignments WHERE user_id = %s

--- a/potato/database/mysql_user_state.py
+++ b/potato/database/mysql_user_state.py
@@ -138,6 +138,66 @@ class MysqlUserState(UserState):
 
         self._invalidate_cache()
 
+    def assign_instance_at_index(self, item: Item, index: int) -> bool:
+        """Insert ``item`` at ``index`` in the user's assignment ordering.
+
+        Used by quality-control injection (attention checks, gold standards).
+        Returns False if the item is already assigned. Raises IndexError if
+        ``index`` is outside [0, current_assignment_count].
+        """
+        instance_id = item.get_id()
+        with self.db_manager.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT COUNT(*) FROM user_instance_assignments
+                WHERE user_id = %s AND instance_id = %s
+            """, (self.user_id, instance_id))
+            already = cursor.fetchone()
+            if already is not None and already[0] > 0:
+                return False
+
+            cursor.execute("""
+                SELECT COUNT(*) FROM user_instance_assignments WHERE user_id = %s
+            """, (self.user_id,))
+            count_result = cursor.fetchone()
+            current_count = count_result[0] if count_result is not None else 0
+            if index < 0 or index > current_count:
+                raise IndexError(
+                    f"assign_instance_at_index: index {index} out of range "
+                    f"[0, {current_count}]"
+                )
+
+            # Shift later orders up to make room for the insert.
+            cursor.execute("""
+                UPDATE user_instance_assignments
+                SET assignment_order = assignment_order + 1
+                WHERE user_id = %s AND assignment_order >= %s
+            """, (self.user_id, index))
+            cursor.execute("""
+                INSERT INTO user_instance_assignments (user_id, instance_id, assignment_order)
+                VALUES (%s, %s, %s)
+            """, (self.user_id, instance_id, index))
+
+            # Rebalance the user's cursor.
+            cursor.execute("""
+                SELECT current_instance_index FROM user_states WHERE user_id = %s
+            """, (self.user_id,))
+            current_index_result = cursor.fetchone()
+            current_index = current_index_result[0] if current_index_result is not None else -1
+            if current_index == -1:
+                new_index = 0
+            elif current_index >= index:
+                new_index = current_index + 1
+            else:
+                new_index = current_index
+            cursor.execute("""
+                UPDATE user_states SET current_instance_index = %s WHERE user_id = %s
+            """, (new_index, self.user_id))
+            conn.commit()
+
+        self._invalidate_cache()
+        return True
+
     def unassign_instance(self, instance_id: str) -> bool:
         """Remove an instance assignment from the user."""
         with self.db_manager.get_connection() as conn:

--- a/potato/routes.py
+++ b/potato/routes.py
@@ -92,15 +92,16 @@ def _inject_quality_control_item_if_needed(username, user_state):
     ):
         return
 
-    assigned_ids = set(getattr(user_state, "assigned_instance_ids", set()) or set())
+    assigned_ids = set(user_state.get_assigned_instance_ids())
     annotated_ids = set(user_state.get_annotated_instance_ids()) if hasattr(user_state, "get_annotated_instance_ids") else set()
     seen_qc_ids = assigned_ids | annotated_ids
 
-    insert_index = user_state.current_instance_index + 1 if user_state.current_instance_index >= 0 else 0
+    current_index = user_state.get_current_instance_index()
+    insert_index = current_index + 1 if current_index >= 0 else 0
 
     def inject_item(item_data):
         item_id = item_data.get("id")
-        if not item_id or item_id in user_state.instance_id_ordering or item_id in seen_qc_ids:
+        if not item_id or item_id in seen_qc_ids:
             return False
 
         prepared_item = dict(item_data)
@@ -116,16 +117,12 @@ def _inject_quality_control_item_if_needed(username, user_state):
                 existing_data = existing_item.get_data()
                 if "displayed_text" not in existing_data:
                     existing_data["displayed_text"] = prepared_item["displayed_text"]
+            item = item_manager.get_item(item_id)
         else:
             item_manager.add_item(item_id, prepared_item)
+            item = item_manager.get_item(item_id)
 
-        if item_id in user_state.assigned_instance_ids:
-            return False
-
-        user_state.instance_id_ordering.insert(insert_index, item_id)
-        user_state.assigned_instance_ids.add(item_id)
-        user_state.instance_id_to_order = user_state.generate_id_order_mapping(user_state.instance_id_ordering)
-        return True
+        return user_state.assign_instance_at_index(item, insert_index)
 
     if qc_manager.should_inject_attention_check(username):
         attention_item = qc_manager.get_attention_check_item(username)

--- a/potato/user_state_management.py
+++ b/potato/user_state_management.py
@@ -1085,6 +1085,16 @@ class UserState:
     def assign_instance(self, item: Item) -> None:
         raise NotImplementedError()
 
+    def assign_instance_at_index(self, item: Item, index: int) -> bool:
+        """Insert an item at a specific position in the user's assignment
+        ordering. Used by quality-control injection (attention checks, gold
+        standards) to place an item right after the user's current cursor
+        without going to the end of the queue.
+
+        Returns False if the item was already assigned. Raises IndexError
+        if index is outside [0, len(ordering)]."""
+        raise NotImplementedError()
+
     def unassign_instance(self, instance_id: str) -> bool:
         raise NotImplementedError()
 
@@ -1905,6 +1915,25 @@ class InMemoryUserState(UserState):
         # If this is the first assigned instance, set the current instance to be the first one
         if self.current_instance_index == -1:
             self.current_instance_index = 0
+
+    def assign_instance_at_index(self, item: Item, index: int) -> bool:
+        """Insert ``item`` at ``index`` in the user's assignment ordering."""
+        item_id = item.get_id()
+        if item_id in self.assigned_instance_ids:
+            return False
+        if index < 0 or index > len(self.instance_id_ordering):
+            raise IndexError(
+                f"assign_instance_at_index: index {index} out of range "
+                f"[0, {len(self.instance_id_ordering)}]"
+            )
+        self.instance_id_ordering.insert(index, item_id)
+        self.assigned_instance_ids.add(item_id)
+        self.instance_id_to_order = self.generate_id_order_mapping(self.instance_id_ordering)
+        if self.current_instance_index == -1:
+            self.current_instance_index = 0
+        elif self.current_instance_index >= index:
+            self.current_instance_index += 1
+        return True
 
     def unassign_instance(self, instance_id: str) -> bool:
         """Remove an uncompleted assignment from this user."""

--- a/potato/user_state_management.py
+++ b/potato/user_state_management.py
@@ -2811,6 +2811,9 @@ class InMemoryUserState(UserState):
 
         user_state.instance_id_ordering = j['instance_id_ordering']
         user_state.assigned_instance_ids = set(j['instance_id_ordering'])
+        user_state.instance_id_to_order = user_state.generate_id_order_mapping(
+            user_state.instance_id_ordering
+        )
         user_state.current_instance_index = j['current_instance_index']
 
         # Restore behavioral data (used for interaction tracking)

--- a/tests/unit/test_assignment_reclaim.py
+++ b/tests/unit/test_assignment_reclaim.py
@@ -179,6 +179,51 @@ def test_blocked_user_reclaim_survives_save_user_state_failure(monkeypatch, capl
         "expected a warning log mentioning the failing user"
 
 
+def test_prolific_dropped_user_can_be_reassigned_after_reclaim(monkeypatch):
+    """After a Prolific worker is dropped and their items are reclaimed,
+    the same items must be freely reassignable (to that user or others)."""
+    manager = _manager_with_items()
+    user = InMemoryUserState("PROLIFIC_PID_X")
+    user.assign_instance(manager.get_item("item_1"))
+    user.assign_instance(manager.get_item("item_2"))
+
+    class StubUserStateManager:
+        def get_user_state(self, user_id):
+            return user if user_id == "PROLIFIC_PID_X" else None
+
+        def save_user_state(self, user_state):
+            return None
+
+    monkeypatch.setattr(
+        "potato.user_state_management.get_user_state_manager",
+        lambda: StubUserStateManager(),
+    )
+    monkeypatch.setattr(
+        "potato.item_state_management.get_item_state_manager",
+        lambda: manager,
+    )
+
+    study = ProlificStudy.__new__(ProlificStudy)
+    study.user_status_dict = {
+        "RETURNED": {"PROLIFIC_PID_X"},
+        "TIMED-OUT": set(),
+        "REJECTED": set(),
+    }
+    study.reclaim_dropped_user_assignments()
+
+    # The items are now back in the pool — assignment_timestamps for the
+    # dropped user must be cleared so a reconnecting worker doesn't trip
+    # the stale-assignment heuristic on items they were never reassigned.
+    assert "PROLIFIC_PID_X" not in manager.assignment_timestamps.get("item_1", {})
+    assert "PROLIFIC_PID_X" not in manager.assignment_timestamps.get("item_2", {})
+    assert set(manager.remaining_instance_ids) >= {"item_1", "item_2"}
+
+    # A new (or returning) user can now be reassigned the reclaimed items.
+    fresh_user = InMemoryUserState("PROLIFIC_PID_X")
+    fresh_user.assign_instance(manager.get_item("item_1"))
+    assert "item_1" in fresh_user.get_assigned_instance_ids()
+
+
 def test_concurrent_reclaim_for_users_is_idempotent(monkeypatch):
     """Two threads racing on reclaim_unannotated_assignments_for_users for the
     same user set must agree on the final state and never double-reclaim."""

--- a/tests/unit/test_assignment_reclaim.py
+++ b/tests/unit/test_assignment_reclaim.py
@@ -1,3 +1,4 @@
+import threading
 import time
 
 from potato.item_state_management import Item, ItemStateManager, Label
@@ -176,6 +177,53 @@ def test_blocked_user_reclaim_survives_save_user_state_failure(monkeypatch, capl
     assert any("disk on fire" in r.getMessage() or "save_fail_worker" in r.getMessage()
                for r in caplog.records), \
         "expected a warning log mentioning the failing user"
+
+
+def test_concurrent_reclaim_for_users_is_idempotent(monkeypatch):
+    """Two threads racing on reclaim_unannotated_assignments_for_users for the
+    same user set must agree on the final state and never double-reclaim."""
+    manager = _manager_with_items()
+    user = InMemoryUserState("racing_worker")
+    user.advance_to_phase(UserPhase.ANNOTATION, None)
+    for item_id in ("item_1", "item_2", "item_3"):
+        user.assign_instance(manager.get_item(item_id))
+
+    class StubUserStateManager:
+        def get_user_state(self, user_id):
+            return user if user_id == "racing_worker" else None
+
+        def save_user_state(self, user_state):
+            return None
+
+    monkeypatch.setattr(
+        "potato.user_state_management.get_user_state_manager",
+        lambda: StubUserStateManager(),
+    )
+
+    results = [None, None]
+    barrier = threading.Barrier(2)
+
+    def worker(idx):
+        barrier.wait()
+        results[idx] = manager.reclaim_unannotated_assignments_for_users(
+            ["racing_worker"],
+            reason=f"thread_{idx}",
+        )
+
+    t1 = threading.Thread(target=worker, args=(0,))
+    t2 = threading.Thread(target=worker, args=(1,))
+    t1.start(); t2.start()
+    t1.join(); t2.join()
+
+    # Combined claims across both threads cover exactly the three items, no duplicates
+    claimed = []
+    for r in results:
+        claimed.extend(r.get("racing_worker", []))
+    assert sorted(claimed) == ["item_1", "item_2", "item_3"]
+    assert user.get_assigned_instance_ids() == set()
+    # remaining_instance_ids may legitimately contain each item once
+    for iid in ("item_1", "item_2", "item_3"):
+        assert list(manager.remaining_instance_ids).count(iid) == 1
 
 
 def test_prolific_reclaim_survives_per_user_save_failure(monkeypatch, caplog):

--- a/tests/unit/test_assignment_reclaim.py
+++ b/tests/unit/test_assignment_reclaim.py
@@ -144,3 +144,71 @@ def test_quality_control_block_reclaims_batch_and_does_not_keep_failed_response(
     assert set(reclaimed) == {"item_1", "item_2"}
     assert user.get_assigned_instance_ids() == set()
     assert user.has_annotated("item_2") is False
+
+
+def test_blocked_user_reclaim_survives_save_user_state_failure(monkeypatch, caplog):
+    """If save_user_state raises, the in-memory reclaim must still hold and
+    the failure must be logged rather than swallowed silently."""
+    from potato import routes
+
+    manager = _manager_with_items()
+    user = InMemoryUserState("save_fail_worker")
+    user.advance_to_phase(UserPhase.ANNOTATION, None)
+    user.assign_instance(manager.get_item("item_1"))
+    user.assign_instance(manager.get_item("item_2"))
+
+    class FailingUserStateManager:
+        def save_user_state(self, user_state):
+            raise RuntimeError("disk on fire")
+
+    monkeypatch.setattr(routes, "get_item_state_manager", lambda: manager)
+    monkeypatch.setattr(routes, "get_user_state_manager", lambda: FailingUserStateManager())
+
+    with caplog.at_level("WARNING", logger="potato.routes"):
+        reclaimed = routes._reclaim_blocked_user_assignments(
+            "save_fail_worker",
+            user,
+            current_instance_id="item_1",
+        )
+
+    assert set(reclaimed) == {"item_1", "item_2"}
+    assert user.get_assigned_instance_ids() == set()
+    assert any("disk on fire" in r.getMessage() or "save_fail_worker" in r.getMessage()
+               for r in caplog.records), \
+        "expected a warning log mentioning the failing user"
+
+
+def test_prolific_reclaim_survives_per_user_save_failure(monkeypatch, caplog):
+    """A save failure for one dropped user must not block reclaim for others."""
+    manager = _manager_with_items()
+    user_a = InMemoryUserState("PROLIFIC_PID_A")
+    user_b = InMemoryUserState("PROLIFIC_PID_B")
+    user_a.assign_instance(manager.get_item("item_1"))
+    user_b.assign_instance(manager.get_item("item_2"))
+
+    class PartiallyFailingUserStateManager:
+        def get_user_state(self, user_id):
+            return {"PROLIFIC_PID_A": user_a, "PROLIFIC_PID_B": user_b}.get(user_id)
+
+        def save_user_state(self, user_state):
+            if user_state.get_user_id() == "PROLIFIC_PID_A":
+                raise RuntimeError("simulated save failure for A")
+            return None
+
+    monkeypatch.setattr(
+        "potato.user_state_management.get_user_state_manager",
+        lambda: PartiallyFailingUserStateManager(),
+    )
+
+    with caplog.at_level("WARNING"):
+        result = manager.reclaim_unannotated_assignments_for_users(
+            ["PROLIFIC_PID_A", "PROLIFIC_PID_B"],
+            reason="prolific_dropped",
+        )
+
+    # Both users had their assignments reclaimed in memory, even though A's save failed.
+    assert set(result.keys()) == {"PROLIFIC_PID_A", "PROLIFIC_PID_B"}
+    assert user_a.get_assigned_instance_ids() == set()
+    assert user_b.get_assigned_instance_ids() == set()
+    assert any("PROLIFIC_PID_A" in r.getMessage() for r in caplog.records), \
+        "expected warning naming the failing user"

--- a/tests/unit/test_database_user_state.py
+++ b/tests/unit/test_database_user_state.py
@@ -551,6 +551,82 @@ class TestMysqlUserStateIntegration:
         pass
 
 
+class TestMysqlBackendReclaimSmoke:
+    """End-to-end smoke test for the QC-block reclaim flow against a real
+    MysqlUserState instance (with mocked DB). Acts as a tripwire for future
+    code in the reclaim path that direct-accesses InMemoryUserState-only
+    attributes like assigned_instance_ids or instance_id_ordering."""
+
+    @pytest.fixture
+    def mock_db_manager(self):
+        mock_manager = Mock()
+        mock_connection = Mock()
+        mock_cursor = Mock()
+        mock_connection.cursor.return_value = mock_cursor
+        context_mock = Mock()
+        context_mock.__enter__ = Mock(return_value=mock_connection)
+        context_mock.__exit__ = Mock(return_value=None)
+        mock_manager.get_connection.return_value = context_mock
+        return mock_manager, mock_connection, mock_cursor
+
+    def test_blocked_user_reclaim_works_against_mysql_user_state(self, mock_db_manager, monkeypatch):
+        """The QC-block helper must run through MysqlUserState without hitting
+        AttributeError on InMemoryUserState-only attributes."""
+        from potato import routes
+        from potato.item_state_management import ItemStateManager
+
+        mock_manager, mock_conn, mock_cursor = mock_db_manager
+        user_state = MysqlUserState("blocked_mysql_user", mock_manager)
+
+        # Drive the SQL responses for the whole reclaim sequence with one
+        # assigned item and no annotations:
+        #   get_assigned_instance_ids (fetchall) -> [("item_z",)]
+        #   has_annotated (fetchall)            -> [(0,), (0,)]
+        #   unassign SELECT order               -> (0,)
+        #   get_current_instance_index SELECT   -> (0,)
+        #   SELECT COUNT(*) post-delete         -> (0,)
+        mock_cursor.fetchall.side_effect = [
+            [("item_z",)],   # get_assigned_instance_ids
+            [(0,), (0,)],    # has_annotated UNION counts
+        ]
+        mock_cursor.fetchone.side_effect = [
+            (0,),  # unassign: removed_order
+            (0,),  # unassign: current_instance_index
+            (0,),  # unassign: post-delete COUNT
+        ]
+
+        item_manager = ItemStateManager(
+            {"assignment_strategy": "fixed_order", "max_annotations_per_item": 1}
+        )
+        item_manager.add_items({"item_z": {"id": "item_z", "text": "z"}})
+        # Pretend the user was tracked as an annotator candidate (matches what
+        # assign_instances_to_user would have set up in production).
+        item_manager.instance_annotators["item_z"].add("blocked_mysql_user")
+
+        class StubUSM:
+            def save_user_state(self, _us):
+                return None
+
+        monkeypatch.setattr(routes, "get_item_state_manager", lambda: item_manager)
+        monkeypatch.setattr(routes, "get_user_state_manager", lambda: StubUSM())
+
+        # The call below would raise AttributeError on the pre-refactor reclaim
+        # path that touched user_state.assigned_instance_ids directly.
+        reclaimed = routes._reclaim_blocked_user_assignments(
+            "blocked_mysql_user",
+            user_state,
+            current_instance_id="item_z",
+        )
+
+        assert reclaimed == ["item_z"]
+        # Verify both per-instance DELETEs (clear_instance_annotations) and
+        # the unassign UPDATE/DELETE all ran against the mock cursor.
+        executed = [c.args[0] for c in mock_cursor.execute.call_args_list]
+        assert any("DELETE FROM label_annotations" in q for q in executed)
+        assert any("DELETE FROM user_instance_assignments" in q for q in executed)
+        assert any("UPDATE user_states SET current_instance_index" in q for q in executed)
+
+
 class TestDatabaseConfiguration:
     """Test database configuration validation."""
 

--- a/tests/unit/test_database_user_state.py
+++ b/tests/unit/test_database_user_state.py
@@ -412,6 +412,93 @@ class TestMysqlUserState:
                                if "UPDATE user_states SET current_instance_index" in c.args[0])
         assert update_idx_call.args[1] == (1, "test_user")
 
+    def test_assign_instance_at_index_returns_false_when_already_assigned(self, mock_db_manager):
+        """Duplicate assignment short-circuits without DELETE/INSERT/UPDATE."""
+        mock_manager, mock_conn, mock_cursor = mock_db_manager
+
+        user_state = MysqlUserState("test_user", mock_manager)
+        mock_cursor.execute.reset_mock()
+        mock_conn.commit.reset_mock()
+        # SELECT COUNT for already-assigned → (1,)
+        mock_cursor.fetchone.side_effect = [(1,)]
+
+        item = Mock(); item.get_id.return_value = "dup_item"
+        result = user_state.assign_instance_at_index(item, 0)
+
+        assert result is False
+        # Only the duplicate-check SELECT should run.
+        assert mock_cursor.execute.call_count == 1
+        mock_conn.commit.assert_not_called()
+
+    def test_assign_instance_at_index_inserts_and_shifts(self, mock_db_manager):
+        """Insert at index 1 with current cursor at 2 must shift later orders
+        and bump the cursor to 3."""
+        mock_manager, mock_conn, mock_cursor = mock_db_manager
+
+        user_state = MysqlUserState("test_user", mock_manager)
+        mock_cursor.execute.reset_mock()
+        mock_conn.commit.reset_mock()
+        # Sequence: not assigned (0,), count=3, current_index=2
+        mock_cursor.fetchone.side_effect = [(0,), (3,), (2,)]
+
+        item = Mock(); item.get_id.return_value = "new_item"
+        result = user_state.assign_instance_at_index(item, 1)
+
+        assert result is True
+        executed = [c.args[0] for c in mock_cursor.execute.call_args_list]
+        assert any("SET assignment_order = assignment_order + 1" in q for q in executed)
+        assert any("INSERT INTO user_instance_assignments" in q for q in executed)
+        update_idx_call = next(c for c in mock_cursor.execute.call_args_list
+                               if "UPDATE user_states SET current_instance_index" in c.args[0])
+        assert update_idx_call.args[1] == (3, "test_user")
+        mock_conn.commit.assert_called_once()
+
+    def test_assign_instance_at_index_after_cursor_leaves_cursor(self, mock_db_manager):
+        """Insert at index 2 with current cursor at 0 must leave the cursor."""
+        mock_manager, mock_conn, mock_cursor = mock_db_manager
+
+        user_state = MysqlUserState("test_user", mock_manager)
+        mock_cursor.execute.reset_mock()
+        mock_conn.commit.reset_mock()
+        # Sequence: not assigned, count=3, current_index=0
+        mock_cursor.fetchone.side_effect = [(0,), (3,), (0,)]
+
+        item = Mock(); item.get_id.return_value = "later_item"
+        assert user_state.assign_instance_at_index(item, 2) is True
+
+        update_idx_call = next(c for c in mock_cursor.execute.call_args_list
+                               if "UPDATE user_states SET current_instance_index" in c.args[0])
+        assert update_idx_call.args[1] == (0, "test_user")
+
+    def test_assign_instance_at_index_empty_state_sets_cursor_to_zero(self, mock_db_manager):
+        """Insert into empty user (cursor = -1) must move cursor to 0."""
+        mock_manager, mock_conn, mock_cursor = mock_db_manager
+
+        user_state = MysqlUserState("test_user", mock_manager)
+        mock_cursor.execute.reset_mock()
+        mock_conn.commit.reset_mock()
+        # Sequence: not assigned, count=0, current_index=-1
+        mock_cursor.fetchone.side_effect = [(0,), (0,), (-1,)]
+
+        item = Mock(); item.get_id.return_value = "first_item"
+        assert user_state.assign_instance_at_index(item, 0) is True
+
+        update_idx_call = next(c for c in mock_cursor.execute.call_args_list
+                               if "UPDATE user_states SET current_instance_index" in c.args[0])
+        assert update_idx_call.args[1] == (0, "test_user")
+
+    def test_assign_instance_at_index_out_of_range_raises(self, mock_db_manager):
+        """Index past the end of the ordering must raise IndexError."""
+        mock_manager, mock_conn, mock_cursor = mock_db_manager
+
+        user_state = MysqlUserState("test_user", mock_manager)
+        # Sequence: not assigned, count=2
+        mock_cursor.fetchone.side_effect = [(0,), (2,)]
+
+        item = Mock(); item.get_id.return_value = "bad_index"
+        with pytest.raises(IndexError):
+            user_state.assign_instance_at_index(item, 5)
+
     def test_unassign_instance_invalidates_cache(self, mock_db_manager):
         """After a successful unassign, cached index/ordering must be cleared."""
         mock_manager, mock_conn, mock_cursor = mock_db_manager

--- a/tests/unit/test_quality_control.py
+++ b/tests/unit/test_quality_control.py
@@ -898,6 +898,20 @@ def test_attention_check_injection_wires_into_annotate_flow(monkeypatch):
                 self.current_phase_and_page = (UserPhase.ANNOTATION, "annotation")
             def get_current_instance(self):
                 return StubItem("item_001")
+            def get_current_instance_index(self):
+                return self.current_instance_index
+            def get_assigned_instance_ids(self):
+                return set(self.assigned_instance_ids)
+            def get_annotated_instance_ids(self):
+                return set()
+            def assign_instance_at_index(self, item, index):
+                if item.get_id() in self.assigned_instance_ids:
+                    return False
+                self.instance_id_ordering.insert(index, item.get_id())
+                self.assigned_instance_ids.add(item.get_id())
+                if self.current_instance_index >= index:
+                    self.current_instance_index += 1
+                return True
             def generate_id_order_mapping(self, ordering):
                 return {iid: idx for idx, iid in enumerate(ordering)}
 
@@ -1060,6 +1074,20 @@ def test_attention_check_injection_reuses_existing_global_item_without_duplicate
                 self.current_phase_and_page = (UserPhase.ANNOTATION, "annotation")
             def get_current_instance(self):
                 return StubItem("item_001")
+            def get_current_instance_index(self):
+                return self.current_instance_index
+            def get_assigned_instance_ids(self):
+                return set(self.assigned_instance_ids)
+            def get_annotated_instance_ids(self):
+                return set()
+            def assign_instance_at_index(self, item, index):
+                if item.get_id() in self.assigned_instance_ids:
+                    return False
+                self.instance_id_ordering.insert(index, item.get_id())
+                self.assigned_instance_ids.add(item.get_id())
+                if self.current_instance_index >= index:
+                    self.current_instance_index += 1
+                return True
             def generate_id_order_mapping(self, ordering):
                 return {iid: idx for idx, iid in enumerate(ordering)}
 
@@ -1132,6 +1160,18 @@ def test_attention_check_is_not_reinjected_for_same_user(monkeypatch):
                 self.current_phase_and_page = (UserPhase.ANNOTATION, "annotation")
             def get_current_instance(self):
                 return StubItem("item_009")
+            def get_current_instance_index(self):
+                return self.current_instance_index
+            def get_assigned_instance_ids(self):
+                return set(self.assigned_instance_ids)
+            def assign_instance_at_index(self, item, index):
+                if item.get_id() in self.assigned_instance_ids:
+                    return False
+                self.instance_id_ordering.insert(index, item.get_id())
+                self.assigned_instance_ids.add(item.get_id())
+                if self.current_instance_index >= index:
+                    self.current_instance_index += 1
+                return True
             def generate_id_order_mapping(self, ordering):
                 return {iid: idx for idx, iid in enumerate(ordering)}
             def get_annotated_instance_ids(self):

--- a/tests/unit/test_user_state_management.py
+++ b/tests/unit/test_user_state_management.py
@@ -150,6 +150,76 @@ def test_get_current_instance_returns_none_for_missing(monkeypatch):
     assert user.current_instance_index == 0  # unchanged
 
 
+def test_assign_instance_at_index_inserts_in_middle_and_shifts_cursor():
+    """Inserting at an index <= current_instance_index must bump the cursor."""
+    from potato.item_state_management import Item
+
+    user = InMemoryUserState("qc_user")
+    user.assign_instance(Item("a", {"text": "a"}))
+    user.assign_instance(Item("b", {"text": "b"}))
+    user.assign_instance(Item("c", {"text": "c"}))
+    user.go_to_index(2)  # currently on "c"
+
+    assert user.assign_instance_at_index(Item("inserted", {"text": "x"}), 1) is True
+
+    assert user.instance_id_ordering == ["a", "inserted", "b", "c"]
+    assert user.get_assigned_instance_ids() == {"a", "inserted", "b", "c"}
+    assert user.instance_id_to_order == {"a": 0, "inserted": 1, "b": 2, "c": 3}
+    # Cursor was on "c" (index 2) → after insertion at index 1, "c" is at 3.
+    assert user.get_current_instance_index() == 3
+
+
+def test_assign_instance_at_index_after_cursor_does_not_move_cursor():
+    """Inserting after current_instance_index must leave the cursor alone."""
+    from potato.item_state_management import Item
+
+    user = InMemoryUserState("qc_user2")
+    user.assign_instance(Item("a", {"text": "a"}))
+    user.assign_instance(Item("b", {"text": "b"}))
+    user.go_to_index(0)  # currently on "a"
+
+    assert user.assign_instance_at_index(Item("after", {"text": "x"}), 1) is True
+
+    assert user.instance_id_ordering == ["a", "after", "b"]
+    assert user.get_current_instance_index() == 0
+
+
+def test_assign_instance_at_index_empty_state_sets_cursor_to_zero():
+    """Inserting into an empty ordering must move the cursor to 0."""
+    from potato.item_state_management import Item
+
+    user = InMemoryUserState("first_item_user")
+    assert user.get_current_instance_index() == -1
+
+    assert user.assign_instance_at_index(Item("only", {"text": "x"}), 0) is True
+
+    assert user.instance_id_ordering == ["only"]
+    assert user.get_current_instance_index() == 0
+
+
+def test_assign_instance_at_index_returns_false_when_already_assigned():
+    """Duplicate assignment must be a no-op returning False."""
+    from potato.item_state_management import Item
+
+    user = InMemoryUserState("dup_user")
+    user.assign_instance(Item("a", {"text": "a"}))
+
+    assert user.assign_instance_at_index(Item("a", {"text": "a"}), 0) is False
+    assert user.instance_id_ordering == ["a"]
+
+
+def test_assign_instance_at_index_out_of_range_raises():
+    """An index past the end of the ordering must raise IndexError."""
+    from potato.item_state_management import Item
+
+    user = InMemoryUserState("bad_index_user")
+    user.assign_instance(Item("a", {"text": "a"}))
+
+    import pytest
+    with pytest.raises(IndexError):
+        user.assign_instance_at_index(Item("b", {"text": "b"}), 5)
+
+
 def test_load_round_trip_preserves_assignment_bookkeeping_invariants(monkeypatch, temp_user_dir):
     """After save+load, the three assignment-tracking structures must stay in
     sync: assigned_instance_ids == set(instance_id_ordering), and

--- a/tests/unit/test_user_state_management.py
+++ b/tests/unit/test_user_state_management.py
@@ -150,6 +150,76 @@ def test_get_current_instance_returns_none_for_missing(monkeypatch):
     assert user.current_instance_index == 0  # unchanged
 
 
+def test_load_round_trip_preserves_assignment_bookkeeping_invariants(monkeypatch, temp_user_dir):
+    """After save+load, the three assignment-tracking structures must stay in
+    sync: assigned_instance_ids == set(instance_id_ordering), and
+    instance_id_to_order maps each id to its index in instance_id_ordering.
+
+    Regression: load() previously left instance_id_to_order as {} unless the
+    prune step happened to fire, which silently broke unassign_instance and
+    any other code that consulted the index map."""
+    from potato.item_state_management import Item
+
+    user = InMemoryUserState("rt_user")
+    user.current_phase_and_page = (UserPhase.ANNOTATION, None)
+    for iid in ("alpha", "beta", "gamma"):
+        user.assign_instance(Item(iid, {"text": iid}))
+    user.go_to_index(2)
+    user.save(temp_user_dir)
+
+    class AllItemsPresent:
+        def has_item(self, item_id):
+            return True
+        def get_item(self, item_id):
+            return Item(item_id, {"text": item_id})
+
+    monkeypatch.setattr(
+        "potato.user_state_management.get_item_state_manager",
+        lambda: AllItemsPresent(),
+    )
+
+    loaded = InMemoryUserState.load(temp_user_dir)
+
+    assert loaded.instance_id_ordering == ["alpha", "beta", "gamma"]
+    assert loaded.get_assigned_instance_ids() == {"alpha", "beta", "gamma"}
+    assert loaded.instance_id_to_order == {"alpha": 0, "beta": 1, "gamma": 2}
+    assert loaded.get_current_instance_index() == 2
+
+
+def test_load_then_unassign_works_without_prune(monkeypatch, temp_user_dir):
+    """Direct regression for the load-without-prune scenario: a freshly loaded
+    user must be able to have an assignment reclaimed without depending on
+    prune_missing_assigned_instances to first repopulate instance_id_to_order."""
+    from potato.item_state_management import Item
+
+    user = InMemoryUserState("reclaim_after_load")
+    user.current_phase_and_page = (UserPhase.ANNOTATION, None)
+    for iid in ("x", "y", "z"):
+        user.assign_instance(Item(iid, {"text": iid}))
+    user.save(temp_user_dir)
+
+    # Stub out the item manager so prune does NOT fire (all items still exist).
+    class AllItemsPresent:
+        def has_item(self, item_id):
+            return True
+        def get_item(self, item_id):
+            return Item(item_id, {"text": item_id})
+
+    monkeypatch.setattr(
+        "potato.user_state_management.get_item_state_manager",
+        lambda: AllItemsPresent(),
+    )
+
+    loaded = InMemoryUserState.load(temp_user_dir)
+
+    # unassign_instance reads instance_id_to_order via generate_id_order_mapping;
+    # if load left it stale, the bookkeeping below diverges.
+    assert loaded.unassign_instance("y") is True
+    assert loaded.instance_id_ordering == ["x", "z"]
+    assert loaded.instance_id_to_order == {"x": 0, "z": 1}
+    assert loaded.get_assigned_instance_ids() == {"x", "z"}
+
+
 def test_load_prunes_missing_items(monkeypatch, temp_user_dir):
     """Loading persisted state should automatically prune stale items."""
     user = InMemoryUserState("load_prune_user")


### PR DESCRIPTION
Follow-up to #155 and #156 covering the 8 deep-analysis items I flagged after reviewing the reclaim PR. One commit per item for easy review.

## Summary

**Bug fixes**
- `fix: regenerate instance_id_to_order on InMemoryUserState load` — `load()` left this dict as `{}`, only repaired as a side effect of `prune_missing_assigned_instances` or `unassign_instance`. Routes that consulted the dict relied on a fallback path. Regenerate on every load; regression test fails on pre-fix code.

**Backend parity**
- `refactor: assign_instance_at_index public API for QC injection` — `routes._inject_quality_control_item_if_needed` mutated `InMemoryUserState` internals directly, breaking on the MySQL backend with AttributeError. New public method on `UserState` base, implemented on both backends.

**Test coverage**
- `test: end-to-end QC-block reclaim smoke test on MysqlUserState` — drives the full reclaim flow through a real `MysqlUserState` (mock DB). Tripwire for future direct-attribute regressions.
- `test: reclaim survives save_user_state failures` — `_reclaim_blocked_user_assignments` and `reclaim_unannotated_assignments_for_users` must warn-and-continue rather than abandon in-memory reclaim.
- `test: concurrent reclaim for overlapping users is idempotent` — two threads racing on the same user set produce a partition, no double-reclaim.
- `test: Prolific worker can reconnect cleanly after being dropped` — `assignment_timestamps` cleared, items reassignable.

**Documentation**
- `docs: document MysqlUserState link/event annotation gap` — `link_annotations` / `event_annotations` tables don't exist on the MySQL backend; surface this in the class docstring.
- `docs: explain transaction-isolation dependency in unassign_instance` — note why `get_current_instance_index()` opens a separate connection mid-transaction.

## Test plan

- [x] `pytest tests/unit/test_assignment_reclaim.py tests/unit/test_database_user_state.py tests/unit/test_user_state_management.py tests/unit/test_quality_control.py tests/unit/test_prolific_integration.py tests/unit/test_phase_flow_navigation.py tests/unit/test_navigation_reorder_interaction.py tests/unit/test_annotation_navigation.py -q` → 190 passed
- [x] Confirmed the load() regression test fails on master without the fix
- [x] No new failures in the broader unit suite