### PR TITLE
Add configurable annotation retention for reclaimed assignments

### DIFF
--- a/docs/advanced/task_assignment.md
+++ b/docs/advanced/task_assignment.md
@@ -169,18 +169,50 @@ assignment:
 
 For crowdsourcing batches, workers can return, time out, or fail quality checks after
 receiving a batch of assigned items. Potato reclaims assigned-but-unannotated items
-so they can be assigned again. Completed annotations are kept.
+so they can be assigned again. Completed annotations are kept by default.
 
 ```yaml
 instance_reclaim:
   enabled: true
   timeout_hours: 24
+  preserve_completed_annotations: true
 ```
 
 Reclaiming happens automatically for stale assignments when assignment runs, and for
 Prolific workers whose submissions become `RETURNED`, `TIMED-OUT`, or `REJECTED`
 when Prolific submission status is refreshed. Users blocked by attention-check
 failure also release their unannotated assignments immediately.
+
+You can choose whether completed annotations from reclaimed users are preserved.
+This can be useful when you trust partial work from timed-out Prolific workers but
+want to discard all work from users blocked by quality control:
+
+```yaml
+instance_reclaim:
+  enabled: true
+  timeout_hours: 24
+
+  # Default for reclaim reasons not overridden below.
+  preserve_completed_annotations: true
+
+  prolific:
+    preserve_completed_annotations: true
+    status_policies:
+      TIMED-OUT:
+        preserve_completed_annotations: true
+      RETURNED:
+        preserve_completed_annotations: true
+      REJECTED:
+        preserve_completed_annotations: false
+
+  quality_control:
+    preserve_completed_annotations: false
+```
+
+When `preserve_completed_annotations` is `false`, Potato clears that user's
+annotations for their assigned items, removes their annotator credit from those
+items, and returns the items to the assignment pool. The failed attention-check
+response that triggers a block is never kept.
 
 ---
 

--- a/docs/deployment/crowdsourcing.md
+++ b/docs/deployment/crowdsourcing.md
@@ -155,6 +155,22 @@ assigned-but-unannotated items from workers whose submissions are `RETURNED`,
 `TIMED-OUT`, or `REJECTED`, so abandoned batches can be assigned to other workers.
 Annotations already completed by those workers are preserved.
 
+If your study should treat dropout reasons differently, configure
+`instance_reclaim`. For example, preserve completed annotations from timed-out
+workers but discard annotations from rejected workers:
+
+```yaml
+instance_reclaim:
+  enabled: true
+  prolific:
+    preserve_completed_annotations: true
+    status_policies:
+      TIMED-OUT:
+        preserve_completed_annotations: true
+      REJECTED:
+        preserve_completed_annotations: false
+```
+
 ### Setup Prolific API
 
 1. **Get your Prolific API token** from your [Prolific account settings](https://app.prolific.com/account/general)

--- a/docs/workflow/quality_control.md
+++ b/docs/workflow/quality_control.md
@@ -401,6 +401,13 @@ attention_checks:
     warn_threshold: 2
     block_threshold: 5
 
+# Optional: discard all completed work from QC-blocked users.
+# If omitted, completed annotations are preserved, while the failed
+# attention-check response itself is not kept.
+instance_reclaim:
+  quality_control:
+    preserve_completed_annotations: false
+
 gold_standards:
   enabled: true
   items_file: "data/gold_standards.json"

--- a/potato/item_state_management.py
+++ b/potato/item_state_management.py
@@ -768,6 +768,7 @@ class ItemStateManager:
         reclaim_config = config.get('instance_reclaim', {})
         self.reclaim_enabled = reclaim_config.get('enabled', False)
         self.reclaim_timeout_hours = reclaim_config.get('timeout_hours', 24)
+        self.reclaim_config = reclaim_config
 
         # Queue of remaining instances to be assigned
         self.remaining_instance_ids = deque()
@@ -1575,16 +1576,113 @@ class ItemStateManager:
         )
         return True
 
+    def _clear_completed_assignment(
+        self,
+        user_state: 'UserState',
+        instance_id: str,
+        reason: str = "assignment_reclaim",
+    ) -> bool:
+        """Clear a completed annotation and release that assignment."""
+        user_id = getattr(user_state, 'user_id', None) or user_state.get_user_id()
+
+        if not user_state.has_annotated(instance_id):
+            return self._reclaim_unannotated_assignment(user_state, instance_id, reason)
+
+        if hasattr(user_state, "clear_instance_annotations"):
+            user_state.clear_instance_annotations(instance_id)
+
+        unassigned = user_state.unassign_instance(instance_id)
+        if not unassigned:
+            return False
+
+        self.instance_annotators[instance_id].discard(user_id)
+        if self.item_annotation_counts[instance_id] > 0:
+            self.item_annotation_counts[instance_id] -= 1
+
+        if instance_id in self.completed_instance_ids:
+            if self.max_annotations_per_item < 0 or len(self.instance_annotators[instance_id]) < self.max_annotations_per_item:
+                self.completed_instance_ids.discard(instance_id)
+
+        if instance_id not in self.completed_instance_ids and instance_id not in self.remaining_instance_ids:
+            self.remaining_instance_ids.append(instance_id)
+
+        if instance_id in self.assignment_timestamps:
+            self.assignment_timestamps[instance_id].pop(user_id, None)
+            if not self.assignment_timestamps[instance_id]:
+                del self.assignment_timestamps[instance_id]
+
+        self.logger.info(
+            "Cleared and reclaimed completed assignment %s from user %s (%s)",
+            instance_id,
+            user_id,
+            reason,
+        )
+        return True
+
+    def should_preserve_completed_annotations(self, reason: str = "assignment_reclaim") -> bool:
+        """Return whether completed annotations should survive a reclaim reason."""
+        default = self.reclaim_config.get('preserve_completed_annotations', True)
+
+        prolific_statuses = {
+            "prolific_returned": "RETURNED",
+            "prolific_timed_out": "TIMED-OUT",
+            "prolific_rejected": "REJECTED",
+        }
+        if reason in prolific_statuses:
+            prolific_config = self.reclaim_config.get("prolific", {})
+            if not isinstance(prolific_config, dict):
+                return default
+
+            prolific_default = prolific_config.get('preserve_completed_annotations', default)
+            status_policy = (
+                prolific_config.get("status_policies", {})
+                if isinstance(prolific_config.get("status_policies", {}), dict)
+                else {}
+            ).get(prolific_statuses[reason], {})
+            if isinstance(status_policy, dict):
+                return status_policy.get('preserve_completed_annotations', prolific_default)
+            return prolific_default
+
+        reason_to_section = {
+            "quality_control_block": ("quality_control",),
+            "stale_assignment": ("stale",),
+            "manual_admin_reclaim": ("manual",),
+            "prolific_dropped": ("prolific",),
+        }
+
+        path = reason_to_section.get(reason)
+        if not path:
+            return default
+
+        value = self.reclaim_config
+        for key in path:
+            if not isinstance(value, dict) or key not in value:
+                return default
+            value = value[key]
+
+        if isinstance(value, dict):
+            return value.get('preserve_completed_annotations', default)
+        return default
+
     def reclaim_unannotated_assignments_for_user(
         self,
         user_state: 'UserState',
         reason: str = "assignment_reclaim",
+        preserve_completed_annotations: Optional[bool] = None,
     ) -> List[str]:
-        """Reclaim all assigned-but-unannotated instances for a user."""
+        """Reclaim assignments for a user according to the retention policy."""
+        if preserve_completed_annotations is None:
+            preserve_completed_annotations = self.should_preserve_completed_annotations(reason)
+
         reclaimed = []
         with self._lock:
             for instance_id in list(user_state.get_assigned_instance_ids()):
-                if self._reclaim_unannotated_assignment(user_state, instance_id, reason):
+                if preserve_completed_annotations:
+                    did_reclaim = self._reclaim_unannotated_assignment(user_state, instance_id, reason)
+                else:
+                    did_reclaim = self._clear_completed_assignment(user_state, instance_id, reason)
+
+                if did_reclaim:
                     reclaimed.append(instance_id)
         return reclaimed
 
@@ -1592,8 +1690,9 @@ class ItemStateManager:
         self,
         user_ids: List[str],
         reason: str = "assignment_reclaim",
+        preserve_completed_annotations: Optional[bool] = None,
     ) -> Dict[str, List[str]]:
-        """Reclaim assigned-but-unannotated instances for several users."""
+        """Reclaim assignments for several users according to the retention policy."""
         from potato.user_state_management import get_user_state_manager
 
         usm = get_user_state_manager()
@@ -1606,6 +1705,7 @@ class ItemStateManager:
             reclaimed = self.reclaim_unannotated_assignments_for_user(
                 user_state,
                 reason=reason,
+                preserve_completed_annotations=preserve_completed_annotations,
             )
             if not reclaimed:
                 continue

--- a/potato/routes.py
+++ b/potato/routes.py
@@ -139,12 +139,16 @@ def _inject_quality_control_item_if_needed(username, user_state):
 
 def _reclaim_blocked_user_assignments(username, user_state, current_instance_id=None):
     """Release unannotated assignments after a user is blocked."""
+    item_manager = get_item_state_manager()
+    preserve_completed = item_manager.should_preserve_completed_annotations("quality_control_block")
+
     if current_instance_id and hasattr(user_state, "clear_instance_annotations"):
         user_state.clear_instance_annotations(current_instance_id)
 
-    reclaimed = get_item_state_manager().reclaim_unannotated_assignments_for_user(
+    reclaimed = item_manager.reclaim_unannotated_assignments_for_user(
         user_state,
         reason="quality_control_block",
+        preserve_completed_annotations=preserve_completed,
     )
 
     if reclaimed:

--- a/potato/server_utils/config_module.py
+++ b/potato/server_utils/config_module.py
@@ -668,6 +668,9 @@ def validate_yaml_structure(config_data: Dict[str, Any], project_dir: str = None
     # Validate quality control configuration if present
     validate_quality_control_config(config_data)
 
+    # Validate assignment reclaim configuration if present
+    validate_instance_reclaim_config(config_data)
+
     # Validate instance display configuration if present
     validate_instance_display_config(config_data)
 
@@ -2152,6 +2155,59 @@ def validate_quality_control_config(config_data: Dict[str, Any]) -> None:
             interval = agreement_config["refresh_interval"]
             if not isinstance(interval, int) or interval < 10:
                 raise ConfigValidationError("agreement_metrics.refresh_interval must be an integer >= 10 seconds")
+
+
+def validate_instance_reclaim_config(config_data: Dict[str, Any]) -> None:
+    """Validate abandoned assignment reclaim configuration."""
+    if "instance_reclaim" not in config_data:
+        return
+
+    reclaim_config = config_data["instance_reclaim"]
+    if not isinstance(reclaim_config, dict):
+        raise ConfigValidationError("instance_reclaim must be a dictionary")
+
+    def validate_bool(section: Dict[str, Any], path: str) -> None:
+        if "preserve_completed_annotations" in section and not isinstance(section["preserve_completed_annotations"], bool):
+            raise ConfigValidationError(f"{path}.preserve_completed_annotations must be a boolean")
+
+    def validate_section(section_name: str) -> None:
+        if section_name not in reclaim_config:
+            return
+        section = reclaim_config[section_name]
+        if not isinstance(section, dict):
+            raise ConfigValidationError(f"instance_reclaim.{section_name} must be a dictionary")
+        validate_bool(section, f"instance_reclaim.{section_name}")
+
+    if "enabled" in reclaim_config and not isinstance(reclaim_config["enabled"], bool):
+        raise ConfigValidationError("instance_reclaim.enabled must be a boolean")
+
+    if "timeout_hours" in reclaim_config:
+        timeout = reclaim_config["timeout_hours"]
+        if not isinstance(timeout, (int, float)) or timeout <= 0:
+            raise ConfigValidationError("instance_reclaim.timeout_hours must be a positive number")
+
+    validate_bool(reclaim_config, "instance_reclaim")
+
+    for section_name in ("stale", "manual", "quality_control", "prolific"):
+        validate_section(section_name)
+
+    prolific = reclaim_config.get("prolific")
+    if isinstance(prolific, dict) and "status_policies" in prolific:
+        status_policies = prolific["status_policies"]
+        if not isinstance(status_policies, dict):
+            raise ConfigValidationError("instance_reclaim.prolific.status_policies must be a dictionary")
+
+        valid_statuses = {"RETURNED", "TIMED-OUT", "REJECTED"}
+        for status, section in status_policies.items():
+            if status not in valid_statuses:
+                raise ConfigValidationError(
+                    "instance_reclaim.prolific.status_policies keys must be one of: RETURNED, TIMED-OUT, REJECTED"
+                )
+            if not isinstance(section, dict):
+                raise ConfigValidationError(
+                    f"instance_reclaim.prolific.status_policies.{status} must be a dictionary"
+                )
+            validate_bool(section, f"instance_reclaim.prolific.status_policies.{status}")
 
 
 def validate_data_directory_config(config_data: Dict[str, Any]) -> None:

--- a/potato/server_utils/prolific_apis.py
+++ b/potato/server_utils/prolific_apis.py
@@ -384,6 +384,19 @@ class ProlificStudy(ProlificBase):
         """
         return list(self.user_status_dict['RETURNED'] | self.user_status_dict['TIMED-OUT'] | self.user_status_dict['REJECTED'])
 
+    def get_dropped_users_by_status(self):
+        """
+        Get dropped participant IDs grouped by Prolific submission status.
+
+        Returns:
+            dict: Mapping from RETURNED, TIMED-OUT, and REJECTED to participant IDs.
+        """
+        return {
+            'RETURNED': list(self.user_status_dict['RETURNED']),
+            'TIMED-OUT': list(self.user_status_dict['TIMED-OUT']),
+            'REJECTED': list(self.user_status_dict['REJECTED']),
+        }
+
     def reclaim_dropped_user_assignments(self):
         """
         Release unannotated Potato assignments for dropped Prolific workers.
@@ -393,16 +406,30 @@ class ProlificStudy(ProlificBase):
         Prolific login, so the item state manager can safely reclaim any
         assigned-but-unannotated instances.
         """
-        dropped_users = self.get_dropped_users()
-        if not dropped_users:
+        dropped_by_status = self.get_dropped_users_by_status()
+        if not any(dropped_by_status.values()):
             return {}
+
+        status_to_reason = {
+            'RETURNED': 'prolific_returned',
+            'TIMED-OUT': 'prolific_timed_out',
+            'REJECTED': 'prolific_rejected',
+        }
 
         try:
             from potato.item_state_management import get_item_state_manager
-            return get_item_state_manager().reclaim_unannotated_assignments_for_users(
-                dropped_users,
-                reason="prolific_dropped",
-            )
+            manager = get_item_state_manager()
+            reclaimed = {}
+            for status, user_ids in dropped_by_status.items():
+                if not user_ids:
+                    continue
+                reclaimed.update(
+                    manager.reclaim_unannotated_assignments_for_users(
+                        user_ids,
+                        reason=status_to_reason[status],
+                    )
+                )
+            return reclaimed
         except Exception as e:
             logging.getLogger(__name__).warning(
                 "Could not reclaim assignments for dropped Prolific users: %s",

--- a/potato/user_state_management.py
+++ b/potato/user_state_management.py
@@ -1098,6 +1098,9 @@ class UserState:
     def unassign_instance(self, instance_id: str) -> bool:
         raise NotImplementedError()
 
+    def clear_instance_annotations(self, instance_id: str) -> None:
+        raise NotImplementedError()
+
     def get_current_instance(self) -> Item:
         raise NotImplementedError()
 

--- a/tests/unit/test_assignment_reclaim.py
+++ b/tests/unit/test_assignment_reclaim.py
@@ -6,12 +6,12 @@ from potato.user_state_management import InMemoryUserState, UserPhase
 from potato.server_utils.prolific_apis import ProlificStudy
 
 
-def _manager_with_items():
+def _manager_with_items(instance_reclaim=None):
     manager = ItemStateManager(
         {
             "assignment_strategy": "fixed_order",
             "max_annotations_per_item": 1,
-            "instance_reclaim": {"enabled": True, "timeout_hours": 1},
+            "instance_reclaim": instance_reclaim or {"enabled": True, "timeout_hours": 1},
         }
     )
     manager.add_items(
@@ -145,6 +145,150 @@ def test_quality_control_block_reclaims_batch_and_does_not_keep_failed_response(
     assert set(reclaimed) == {"item_1", "item_2"}
     assert user.get_assigned_instance_ids() == set()
     assert user.has_annotated("item_2") is False
+
+
+def test_quality_control_block_can_clear_all_completed_annotations(monkeypatch):
+    from potato import routes
+
+    manager = _manager_with_items(
+        {
+            "enabled": True,
+            "timeout_hours": 1,
+            "quality_control": {"preserve_completed_annotations": False},
+        }
+    )
+    user = InMemoryUserState("blocked_worker")
+    user.advance_to_phase(UserPhase.ANNOTATION, None)
+    user.assign_instance(manager.get_item("item_1"))
+    user.assign_instance(manager.get_item("item_2"))
+    user.add_label_annotation("item_1", Label("sentiment", "positive"), "true")
+    user.add_label_annotation("item_2", Label("attention", "wrong"), "true")
+    manager.register_annotator("item_1", user.get_user_id())
+
+    class StubUserStateManager:
+        def save_user_state(self, user_state):
+            return None
+
+    monkeypatch.setattr(routes, "get_item_state_manager", lambda: manager)
+    monkeypatch.setattr(routes, "get_user_state_manager", lambda: StubUserStateManager())
+
+    reclaimed = routes._reclaim_blocked_user_assignments(
+        "blocked_worker",
+        user,
+        current_instance_id="item_2",
+    )
+
+    assert set(reclaimed) == {"item_1", "item_2"}
+    assert user.get_assigned_instance_ids() == set()
+    assert user.has_annotated("item_1") is False
+    assert "blocked_worker" not in manager.instance_annotators["item_1"]
+    assert "item_1" in manager.remaining_instance_ids
+
+
+def test_prolific_status_policies_can_preserve_timeout_and_clear_rejected(monkeypatch):
+    manager = _manager_with_items(
+        {
+            "enabled": True,
+            "timeout_hours": 1,
+            "prolific": {
+                "preserve_completed_annotations": True,
+                "status_policies": {
+                    "TIMED-OUT": {"preserve_completed_annotations": True},
+                    "REJECTED": {"preserve_completed_annotations": False},
+                },
+            },
+        }
+    )
+    timed_out = InMemoryUserState("TIMED_OUT_USER")
+    rejected = InMemoryUserState("REJECTED_USER")
+    for user, item_id in ((timed_out, "item_1"), (rejected, "item_2")):
+        user.advance_to_phase(UserPhase.ANNOTATION, None)
+        user.assign_instance(manager.get_item(item_id))
+        user.add_label_annotation(item_id, Label("sentiment", "positive"), "true")
+        manager.register_annotator(item_id, user.get_user_id())
+
+    class StubUserStateManager:
+        def get_user_state(self, user_id):
+            return {
+                "TIMED_OUT_USER": timed_out,
+                "REJECTED_USER": rejected,
+            }.get(user_id)
+
+        def save_user_state(self, user_state):
+            return None
+
+    monkeypatch.setattr(
+        "potato.user_state_management.get_user_state_manager",
+        lambda: StubUserStateManager(),
+    )
+    monkeypatch.setattr(
+        "potato.item_state_management.get_item_state_manager",
+        lambda: manager,
+    )
+
+    study = ProlificStudy.__new__(ProlificStudy)
+    study.user_status_dict = {
+        "RETURNED": set(),
+        "TIMED-OUT": {"TIMED_OUT_USER"},
+        "REJECTED": {"REJECTED_USER"},
+    }
+
+    reclaimed = study.reclaim_dropped_user_assignments()
+
+    assert reclaimed == {"REJECTED_USER": ["item_2"]}
+    assert timed_out.has_annotated("item_1") is True
+    assert timed_out.get_assigned_instance_ids() == {"item_1"}
+    assert rejected.has_annotated("item_2") is False
+    assert rejected.get_assigned_instance_ids() == set()
+    assert "REJECTED_USER" not in manager.instance_annotators["item_2"]
+
+
+def test_prolific_status_policy_falls_back_to_prolific_default():
+    manager = _manager_with_items(
+        {
+            "enabled": True,
+            "prolific": {"preserve_completed_annotations": False},
+        }
+    )
+
+    assert manager.should_preserve_completed_annotations("prolific_timed_out") is False
+    assert manager.should_preserve_completed_annotations("quality_control_block") is True
+
+
+def test_instance_reclaim_config_validation_accepts_retention_policies():
+    from potato.server_utils.config_module import validate_instance_reclaim_config
+
+    validate_instance_reclaim_config(
+        {
+            "instance_reclaim": {
+                "enabled": True,
+                "timeout_hours": 12,
+                "preserve_completed_annotations": True,
+                "quality_control": {"preserve_completed_annotations": False},
+                "prolific": {
+                    "preserve_completed_annotations": True,
+                    "status_policies": {
+                        "TIMED-OUT": {"preserve_completed_annotations": True},
+                        "REJECTED": {"preserve_completed_annotations": False},
+                    },
+                },
+            }
+        }
+    )
+
+
+def test_instance_reclaim_config_validation_rejects_non_boolean_policy():
+    import pytest
+    from potato.server_utils.config_module import ConfigValidationError, validate_instance_reclaim_config
+
+    with pytest.raises(ConfigValidationError, match="preserve_completed_annotations"):
+        validate_instance_reclaim_config(
+            {
+                "instance_reclaim": {
+                    "quality_control": {"preserve_completed_annotations": "no"},
+                }
+            }
+        )
 
 
 def test_blocked_user_reclaim_survives_save_user_state_failure(monkeypatch, caplog):


### PR DESCRIPTION
I thought it to be appropriate to have more control over how Potato handles completed annotations when workers abandon a study or fail quality checks, so I added configurable ret## Summary

- Add `instance_reclaim.preserve_completed_annotations` as the default retention policy for reclaimed assignments.
- Add separate `instance_reclaim.quality_control.preserve_completed_annotations` behavior for QC-blocked users.
- Add Prolific-specific retention policies, including per-status overrides for `RETURNED`, `TIMED-OUT`, and `REJECTED`.
- Preserve completed annotations by default, while still reclaiming assigned-but-unannotated items.
- Allow stricter configs to clear completed annotations and remove annotator credit when a reclaim reason should invalidate that worker’s work.
- Keep the failed attention-check response from QC-blocked users from being retained.
- Validate the new reclaim config shape.
- Update assignment, crowdsourcing, and quality-control docs.

## Example

```yaml
instance_reclaim:
  enabled: true
  timeout_hours: 24
  preserve_completed_annotations: true

  prolific:
    preserve_completed_annotations: true
    status_policies:
      TIMED-OUT:
        preserve_completed_annotations: true
      RETURNED:
        preserve_completed_annotations: true
      REJECTED:
        preserve_completed_annotations: false

  quality_control:
    preserve_completed_annotations: false
```

## Tests
- python -m pytest tests/unit/test_assignment_reclaim.py -q
- python -m pytest tests/unit/test_assignment_reclaim.py tests/unit/test_quality_control.py tests/unit/test_prolific_integration.py - tests/unit/test_config_validation_enhanced.py -q
- python -m compileall potato/item_state_management.py potato/routes.py potato/server_utils/prolific_apis.py
- potato/server_utils/config_module.py potato/user_state_management.py