### PR TITLE
chore(packaging): drop redundant static globs (MANIFEST.in already covers them)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,13 +111,13 @@ setup(
         ],
     },
     package_data={
+        # NOTE: All of potato/static/ is shipped via MANIFEST.in
+        # (`recursive-include potato/static/ *`) together with
+        # include_package_data=True above. Do NOT re-add static subdirectories
+        # here — they are already packaged recursively, and per-subdir globs
+        # only invite drift as new static/ folders are added.
         "potato": [
             "templates/*.html",
-            "base_html/*.html",
-            "base_html/examples/*.html",
-            "static/*",
-            "static/styles/*",
-            "static/survey_assets/*",
         ],
     },
 )


### PR DESCRIPTION
## Summary

Removes redundant `static/*` globs from `setup.py`'s `package_data`. They were dead weight: `MANIFEST.in` already ships all of `potato/static/` recursively (`recursive-include potato/static/ *`) together with `include_package_data=True`.

## Why

This came out of reviewing #161, where the author added `static/css/*`, `static/js/*`, and `static/vendor/*` to `package_data` believing nested assets weren't packaged (the reported symptom was 404s behind a reverse proxy). They actually were — `MANIFEST.in` has covered `static/` recursively since 2023. The per-subdir globs only invite drift: every time someone adds a new `static/` folder, they think they must register it here too. This is the second such addition.

The 404s in #161 were a URL-prefix problem, not a packaging problem.

## Verification

Built the wheel before and after and diffed the packaged file list:

```text
- 107 static files still ship (identical set)
- 20 templates/*.html still ship
- only change: potato/static/junk.js is no longer present
```

`junk.js` was a stray untracked 116 KB debug copy of `span-manager.js`. Because it was never tracked, clean-checkout release builds were already unaffected — it only leaked into wheels built from a dirty working tree. (Recommendation, separate from this PR: build releases from a clean checkout, e.g. `git archive` or a fresh clone, so untracked local files can never end up in a release.)

## Changes

- `setup.py`: drop redundant `static/*`/`static/styles/*`/`static/survey_assets/*` and dead `base_html/*` entries from `package_data`; keep `templates/*.html`; add a comment directing future edits to `MANIFEST.in`.

No functional change to what gets installed.
