### PR TITLE
Include all template subfolders in package wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,4 @@
-include potato/templates/congrats.html
-include potato/templates/home.html
-include potato/templates/id_login_home.html
-include potato/templates/signup.html
-include potato/templates/error.html
+graft potato/templates
 recursive-include potato/base_html/ *
 recursive-include potato/static/ *
 recursive-include potato/i18n/ *.yaml

--- a/setup.py
+++ b/setup.py
@@ -126,13 +126,11 @@ setup(
         ],
     },
     package_data={
-        # NOTE: All of potato/static/ is shipped via MANIFEST.in
-        # (`recursive-include potato/static/ *`) together with
-        # include_package_data=True above. Do NOT re-add static subdirectories
-        # here — they are already packaged recursively, and per-subdir globs
-        # only invite drift as new static/ folders are added.
+        # Templates and static assets are shipped recursively via MANIFEST.in
+        # together with include_package_data=True above. Do not add per-folder
+        # globs here; new nested asset directories should be included without
+        # requiring packaging changes.
         "potato": [
-            "templates/*.html",
             "i18n/*.yaml",
         ],
     },


### PR DESCRIPTION
`setup.py`'s single glob of `templates/*.html`excluded subfolders from being included for distribution when packaged. Removes the glob from setup.py in favour of a more inclusive line within MANIFEST.in

Very much (admittedly wilfully) not a python packaging expert and there may be a better approach to this, but the current packaging setup was not including templates from within subfolders within the distributed wheel, breaking, among other things, solo mode's setup routes. 