### PR TITLE
fix(templates): a data column named "labels" reached Item.labels, not the data

### DIFF
--- a/potato/flask_server.py
+++ b/potato/flask_server.py
@@ -70,7 +70,7 @@ base_html_dir = os.path.join(cur_program_dir,'base_htmls') #get the dir where th
 #insert the current program dir into sys path
 sys.path.insert(0, cur_program_dir)
 
-from potato.item_state_management import ItemStateManager, Item, Label, SpanAnnotation
+from potato.item_state_management import ItemStateManager, Item, Label, SpanAnnotation, TemplateItem
 from potato.item_state_management import get_item_state_manager, init_item_state_manager
 from potato.user_state_management import UserStateManager, UserState, get_user_state_manager, init_user_state_manager
 from potato.authentication import UserAuthenticator
@@ -3767,7 +3767,10 @@ def render_page_with_annotations(username: str):
         instance=text,
         # Original plain text without span HTML (for data-original-text attribute)
         instance_plain_text=original_plain_text,
-        instance_obj=item,
+        # Wrapped so that a data column named after an Item attribute — a
+        # "labels" column feeding {{instance_obj.labels[0]}} — still reaches
+        # the template. See TemplateItem.
+        instance_obj=TemplateItem(item),
         # Full record dict so schemas like process_reward / trajectory_eval
         # can bind to structured fields (e.g. structured_turns) via the
         # [data-instance-json] element. Transcript-consuming schemes also get a

--- a/potato/item_state_management.py
+++ b/potato/item_state_management.py
@@ -338,6 +338,52 @@ class Item:
         return (f"Item(id:{self.item_id}, data:{self.item_data}, "
                 f"metadata:{self.__dict__.get('_metadata') or {}})")
 
+
+class TemplateItem:
+    """
+    The view of an :class:`Item` that templates get as ``instance_obj``.
+
+    ``Item.__getattr__`` exposes data fields as attributes, but Python calls it
+    only when normal lookup fails. A data field named after a real attribute
+    therefore never reaches the template: ``{{instance_obj.labels[0]}}`` over a
+    record with a ``labels`` column resolved to ``Item.labels``, the empty
+    annotation dict, and every dynamic label rendered blank (issue #170).
+
+    This wrapper resolves data fields first and delegates everything else to
+    the item, so a data column can carry any name. It does not change ``Item``
+    itself: ``labels`` and ``span_annotations`` stay writable for the forks
+    that use them, and Python callers keep the real object.
+    """
+
+    def __init__(self, item):
+        self._item = item
+
+    def __getattr__(self, name):
+        # Underscored names are never data fields. Answering for them here
+        # would also recurse through _item before __init__ has set it.
+        if not name.startswith("_"):
+            data = self._item.item_data
+            if isinstance(data, dict) and name in data:
+                return data[name]
+        return getattr(self._item, name)
+
+    def __getitem__(self, key):
+        data = self._item.item_data
+        if isinstance(data, dict):
+            return data[key]
+        raise KeyError(key)
+
+    def __contains__(self, key):
+        data = self._item.item_data
+        return isinstance(data, dict) and key in data
+
+    def __str__(self):
+        return str(self._item)
+
+    def __repr__(self):
+        return f"TemplateItem({self._item!r})"
+
+
 class Label:
     """
     A utility class for representing a single label in any annotation scheme.

--- a/tests/unit/test_qa_bugfix_regressions.py
+++ b/tests/unit/test_qa_bugfix_regressions.py
@@ -335,6 +335,47 @@ class TestItemExposesDataFields:
             _ = it.__wrapped__
 
 
+class TestTemplateItemResolvesDataFirst:
+    """Issue #170: a data column named after an Item attribute must still
+    reach the template. `instance_obj.labels[0]` over a record with a "labels"
+    column used to resolve to Item.labels — the empty annotation dict — and
+    every dynamic label rendered blank."""
+
+    def test_colliding_data_field_wins_in_templates(self):
+        from potato.item_state_management import Item, TemplateItem
+        view = TemplateItem(Item("1", {"labels": ["Sounds great", "Coool"]}))
+        assert view.labels[0] == "Sounds great"
+
+    def test_the_item_itself_is_unchanged(self):
+        from potato.item_state_management import Item, TemplateItem
+        item = Item("1", {"labels": ["Sounds great"]})
+        TemplateItem(item)
+        assert item.labels == {}
+
+    def test_non_colliding_fields_and_methods_still_resolve(self):
+        from potato.item_state_management import Item, TemplateItem
+        view = TemplateItem(Item("1", {"gifs": ["one.gif"], "text": "hi"}))
+        assert view.gifs[0] == "one.gif"
+        assert view.item_id == "1"
+        assert view.get_text() == "hi"
+        assert view.get_data() == {"gifs": ["one.gif"], "text": "hi"}
+
+    def test_missing_field_raises_attribute_error(self):
+        from potato.item_state_management import Item, TemplateItem
+        view = TemplateItem(Item("1", {"text": "hi"}))
+        with pytest.raises(AttributeError):
+            _ = view.nonexistent_field
+
+    def test_the_view_renders_the_example_labels(self):
+        from jinja2 import Template
+        from potato.item_state_management import Item, TemplateItem
+        item = Item("1", {"text": "Is not this awesome?!",
+                          "labels": ["Sounds great", "Coool", "Nice"]})
+        html = Template("{{instance_obj.labels[0]}}|{{instance_obj.labels[2]}}").render(
+            instance_obj=TemplateItem(item))
+        assert html == "Sounds great|Nice"
+
+
 class TestPromptOptimizerConstructs:
     """F-022: PromptOptimizer must accept prompt_optimization as a dataclass
     (not only a dict); previously it called .get() on the dataclass -> crash


### PR DESCRIPTION
Fixes #170.

## What happened

`examples/classification/check-box-dynamic-labels` renders three blank checkboxes.

The config asks for `{{instance_obj.labels[0]}}` and the data file carries a `labels` column, but `instance_obj` was the `Item` itself. `Item.__getattr__` exposes data fields as attributes, and Python calls it only when normal attribute lookup fails. The vestigial `Item.labels` property answered instead. That property returns the empty annotation dict, `[0]` on an empty dict is `Undefined`, and Jinja prints `Undefined` as the empty string. No error, no log line, three empty labels.

## Why not rename the column

A rename fixes the shipped example and leaves the trap. Every dataset with a column called `labels`, `span_annotations`, `metadata` or `item_data` hits the same silence, and nothing in the config shows the collision.

## The fix

Templates now get a `TemplateItem` view of the item. It resolves data fields first and delegates everything else to the item, so a data column can carry any name.

`Item` is untouched. `labels` and `span_annotations` stay writable for the forks their docstrings were kept for, and Python callers keep the real object.

## Verification

Ran the shipped example on both revisions and read the served page.

- Before: `appropriateness:::` three times, with nothing after the colons.
- After: `appropriateness:::Sounds great`, `:::Coool`, `:::Nice`.

Five regression tests were added in `tests/unit/test_qa_bugfix_regressions.py`. One renders the example expression through Jinja. `tests/unit/test_qa_bugfix_regressions.py` and `tests/unit/test_item_store.py` pass, except `test_no_production_module_indexes_the_mapping`, which also fails on `master` before this change.